### PR TITLE
Use proper string encoding when deriving policyId

### DIFF
--- a/src/policies/hrac.ts
+++ b/src/policies/hrac.ts
@@ -21,7 +21,7 @@ export class HRAC {
       new Uint8Array([
         ...publisherVerifyingKey,
         ...bobVerifyingKey,
-        ...fromUtf8(label),
+        ...toBytes(label),
       ])
     ).slice(0, HRAC.BYTE_LENGTH);
     return new HRAC(hrac);

--- a/src/policies/hrac.ts
+++ b/src/policies/hrac.ts
@@ -1,5 +1,5 @@
 import { keccakDigest } from '../crypto/api';
-import { fromHexString } from '../utils';
+import { fromUtf8 } from '../utils';
 
 export class HRAC {
   public static readonly BYTE_LENGTH: number = 16;
@@ -21,7 +21,7 @@ export class HRAC {
       new Uint8Array([
         ...publisherVerifyingKey,
         ...bobVerifyingKey,
-        ...fromHexString(label),
+        ...fromUtf8(label),
       ])
     ).slice(0, HRAC.BYTE_LENGTH);
     return new HRAC(hrac);

--- a/src/policies/hrac.ts
+++ b/src/policies/hrac.ts
@@ -1,5 +1,5 @@
 import { keccakDigest } from '../crypto/api';
-import { fromUtf8 } from '../utils';
+import { toBytes } from '../utils';
 
 export class HRAC {
   public static readonly BYTE_LENGTH: number = 16;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,11 @@ export const toBase64 = (bytes: Uint8Array): string =>
 export const fromBase64 = (str: string): Uint8Array =>
   Buffer.from(str, 'base64');
 
+export const toUtf8 = (bytes: Uint8Array): string =>
+  Buffer.from(bytes).toString('utf-8');
+
+export const fromUtf8 = (str: string): Uint8Array => Buffer.from(str, 'utf-8');
+
 export const toNumber = (bytes: Uint8Array, littleEndian = true): number => {
   const view = new DataView(bytes.buffer, 0);
   switch (bytes.length) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,11 +18,6 @@ export const toBase64 = (bytes: Uint8Array): string =>
 export const fromBase64 = (str: string): Uint8Array =>
   Buffer.from(str, 'base64');
 
-export const toUtf8 = (bytes: Uint8Array): string =>
-  Buffer.from(bytes).toString('utf-8');
-
-export const fromUtf8 = (str: string): Uint8Array => Buffer.from(str, 'utf-8');
-
 export const toNumber = (bytes: Uint8Array, littleEndian = true): number => {
   const view = new DataView(bytes.buffer, 0);
   switch (bytes.length) {


### PR DESCRIPTION
When `Alice` grants a policy, she takes in a `label` directly from the user which is in utf-8 encoding. This `label` attribute undergoes no other transformations as it is passed through `Alice.createPolicy` or the constructor of `BlockchainPolicy` where it is passed to `HRAC.derive`. 

`HRAC.derive` assumes that the label is hex encoded which it is not. My proposed solution is for `HRAC` to assume utf-8 encoding but alternate solutions would be for `Alice` or `BlockchainPolicy` to change the encoding of `label` to hex.