### PR TITLE
[WIP] Decoupling policy granting and generation

### DIFF
--- a/src/characters/alice.ts
+++ b/src/characters/alice.ts
@@ -81,6 +81,21 @@ export class Alice {
     return await policy.enact(ursulas);
   }
 
+  public async generatePolicy(
+    policyParameters: BlockchainPolicyParameters,
+    includeUrsulas?: ChecksumAddress[],
+    excludeUrsulas?: ChecksumAddress[]
+  ): Promise<EnactedPolicy> {
+    const ursulas = await this.porter.getUrsulas(
+      policyParameters.shares,
+      policyParameters.paymentPeriods,
+      excludeUrsulas,
+      includeUrsulas
+    );
+    const policy = await this.createPolicy(policyParameters);
+    return await policy.generateEnactedPolicy(ursulas);
+  }
+
   public generateKFrags(
     bob: RemoteBob,
     label: string,

--- a/src/policies/policy.ts
+++ b/src/policies/policy.ts
@@ -18,6 +18,8 @@ export interface EnactedPolicy {
   revocationKit: RevocationKit;
   aliceVerifyingKey: Uint8Array;
   ursulas: Ursula[];
+  expirationTimestamp: number;
+  valueInWei: number;
 }
 
 export interface BlockchainPolicyParameters {
@@ -115,7 +117,12 @@ export class BlockchainPolicy {
   public async enact(ursulas: Ursula[]): Promise<EnactedPolicy> {
     const ursulaAddresses = ursulas.map((u) => u.checksumAddress);
     await this.publish(ursulaAddresses);
+    return await this.generateEnactedPolicy(ursulas);
+  }
 
+  public async generateEnactedPolicy(
+    ursulas: Ursula[]
+  ): Promise<EnactedPolicy> {
     const treasureMap = await TreasureMap.constructByPublisher(
       this.hrac,
       this.publisher,
@@ -135,6 +142,8 @@ export class BlockchainPolicy {
       revocationKit,
       aliceVerifyingKey: this.publisher.verifyingKey.toBytes(),
       ursulas,
+      expirationTimestamp: (this.expiration.getTime() / 1000) | 0,
+      valueInWei: this.value,
     };
   }
 


### PR DESCRIPTION
The rationale behind this is to decouple the generation of a `Policy` from the actual onchain granting of said `Policy`. This is to allow our smart contracts to be the owner and sponsor of our policies, not `Alice`. 

There may be a more practical way to implement this, but this seems to be the least invasive on the existing API. I see there are a lot of changes for the `0.5.0` candidate so let me know where you think this might best slot into. 