### PR TITLE
Add ability to rebuild dynamic tDec entities from static json

### DIFF
--- a/src/characters/tDec.ts
+++ b/src/characters/tDec.ts
@@ -32,7 +32,7 @@ export async function generateTDecEntities(
   endDate: Date,
   porterUri: string,
   aliceSecretKey: SecretKey = SecretKey.random()
-): Promise<readonly [Enrico, tDecDecrypter, EnactedPolicy]> {
+): Promise<readonly [Enrico, tDecDecrypter, EnactedPolicy, any]> {
   // const configuration = defaultConfiguration(chainId);
   const configuration = { porterUri };
   const bobSecretKey = SecretKey.random();
@@ -63,7 +63,29 @@ export async function generateTDecEntities(
     bobSecretKey,
     bobSecretKey
   );
-  return [encrypter, decrypter, policy];
+
+  const config_json = {"policy_encrypting_key": policy.policyKey,
+                "encrypted_treasure_map": policy.encryptedTreasureMap,
+                "alice_verifying_key": godAlice.verifyingKey,
+                "bob_secret_key": bobSecretKey}
+  return [encrypter, decrypter, policy, config_json];
+}
+
+export async function TDecEntitiesFromConfig(
+  config_json: any,
+  porterUri: string
+): Promise<readonly [Enrico, tDecDecrypter]> {
+  const encrypter = new Enrico(config_json["policy_encrypting_key"], config_json["alice_verifying_key"]);
+
+  const decrypter = new tDecDecrypter(
+    porterUri,
+    config_json["policy_encrypting_key"],
+    config_json["encrypted_treasure_map"],
+    config_json["alice_verifying_key"],
+    config_json["bob_secret_key"],
+    config_json["bob_secret_key"]
+  );
+  return [encrypter, decrypter]
 }
 
 export async function makeTDecDecrypter(

--- a/src/characters/tDec.ts
+++ b/src/characters/tDec.ts
@@ -14,6 +14,13 @@ import { Bob } from './bob';
 import { Enrico } from './enrico';
 import { tDecDecrypter } from './universal-bob';
 
+interface TDecConfig {
+  policyEncryptingKey: PublicKey;
+  encryptedTreasureMap: EncryptedTreasureMap;
+  aliceVerifyingKey: PublicKey;
+  bobSecretKey: SecretKey;
+}
+
 async function getTDecConfig(
   configLabel: string
 ): Promise<Record<string, string>> {
@@ -32,7 +39,7 @@ export async function generateTDecEntities(
   endDate: Date,
   porterUri: string,
   aliceSecretKey: SecretKey = SecretKey.random()
-): Promise<readonly [Enrico, tDecDecrypter, EnactedPolicy, any]> {
+): Promise<readonly [Enrico, tDecDecrypter, EnactedPolicy, TDecConfig]> {
   // const configuration = defaultConfiguration(chainId);
   const configuration = { porterUri };
   const bobSecretKey = SecretKey.random();
@@ -65,30 +72,30 @@ export async function generateTDecEntities(
   );
 
   const config_json = {
-    policy_encrypting_key: policy.policyKey,
-    encrypted_treasure_map: policy.encryptedTreasureMap,
-    alice_verifying_key: godAlice.verifyingKey,
-    bob_secret_key: bobSecretKey,
+    policyEncryptingKey: policy.policyKey,
+    encryptedTreasureMap: policy.encryptedTreasureMap,
+    aliceVerifyingKey: godAlice.verifyingKey,
+    bobSecretKey: bobSecretKey,
   };
   return [encrypter, decrypter, policy, config_json];
 }
 
 export async function TDecEntitiesFromConfig(
-  config_json: any,
+  config_json: TDecConfig,
   porterUri: string
 ): Promise<readonly [Enrico, tDecDecrypter]> {
   const encrypter = new Enrico(
-    config_json['policy_encrypting_key'],
-    config_json['alice_verifying_key']
+    config_json.policyEncryptingKey,
+    config_json.aliceVerifyingKey
   );
 
   const decrypter = new tDecDecrypter(
     porterUri,
-    config_json['policy_encrypting_key'],
-    config_json['encrypted_treasure_map'],
-    config_json['alice_verifying_key'],
-    config_json['bob_secret_key'],
-    config_json['bob_secret_key']
+    config_json.policyEncryptingKey,
+    config_json.encryptedTreasureMap,
+    config_json.aliceVerifyingKey,
+    config_json.bobSecretKey,
+    config_json.bobSecretKey
   );
   return [encrypter, decrypter];
 }

--- a/src/characters/tDec.ts
+++ b/src/characters/tDec.ts
@@ -64,10 +64,12 @@ export async function generateTDecEntities(
     bobSecretKey
   );
 
-  const config_json = {"policy_encrypting_key": policy.policyKey,
-                "encrypted_treasure_map": policy.encryptedTreasureMap,
-                "alice_verifying_key": godAlice.verifyingKey,
-                "bob_secret_key": bobSecretKey}
+  const config_json = {
+    policy_encrypting_key: policy.policyKey,
+    encrypted_treasure_map: policy.encryptedTreasureMap,
+    alice_verifying_key: godAlice.verifyingKey,
+    bob_secret_key: bobSecretKey,
+  };
   return [encrypter, decrypter, policy, config_json];
 }
 
@@ -75,17 +77,20 @@ export async function TDecEntitiesFromConfig(
   config_json: any,
   porterUri: string
 ): Promise<readonly [Enrico, tDecDecrypter]> {
-  const encrypter = new Enrico(config_json["policy_encrypting_key"], config_json["alice_verifying_key"]);
+  const encrypter = new Enrico(
+    config_json['policy_encrypting_key'],
+    config_json['alice_verifying_key']
+  );
 
   const decrypter = new tDecDecrypter(
     porterUri,
-    config_json["policy_encrypting_key"],
-    config_json["encrypted_treasure_map"],
-    config_json["alice_verifying_key"],
-    config_json["bob_secret_key"],
-    config_json["bob_secret_key"]
+    config_json['policy_encrypting_key'],
+    config_json['encrypted_treasure_map'],
+    config_json['alice_verifying_key'],
+    config_json['bob_secret_key'],
+    config_json['bob_secret_key']
   );
-  return [encrypter, decrypter]
+  return [encrypter, decrypter];
 }
 
 export async function makeTDecDecrypter(

--- a/src/characters/universal-bob.ts
+++ b/src/characters/universal-bob.ts
@@ -21,7 +21,7 @@ export class tDecDecrypter {
   constructor(
     porterUri: string,
     private readonly policyEncryptingKey: PublicKey,
-    private readonly encryptedTreasureMap: EncryptedTreasureMap,
+    readonly encryptedTreasureMap: EncryptedTreasureMap,
     private readonly publisherVerifyingKey: PublicKey,
     secretKey: SecretKey,
     verifyingKey: SecretKey

--- a/test/integration/tdec.test.ts
+++ b/test/integration/tdec.test.ts
@@ -1,7 +1,7 @@
 import { SecretKey, VerifiedKeyFrag } from '@nucypher/nucypher-core';
 
 import { Ursula } from '../../src/characters/porter';
-import { generateTDecEntities } from '../../src/characters/tDec';
+import { generateTDecEntities, TDecEntitiesFromConfig } from '../../src/characters/tDec';
 import { ConditionsIntegrator } from '../../src/core';
 import { Conditions, ConditionSet } from '../../src/policies/conditions';
 import { toBytes } from '../../src/utils';
@@ -36,7 +36,7 @@ describe('threshold decryption', () => {
     const makeTreasureMapSpy = mockMakeTreasureMap();
     const encryptTreasureMapSpy = mockEncryptTreasureMap();
 
-    const [encrypter, decrypter, policy] = await generateTDecEntities(
+    const [encrypter, decrypter, policy, config_json] = await generateTDecEntities(
       threshold,
       shares,
       provider,
@@ -96,4 +96,83 @@ describe('threshold decryption', () => {
     expect(retrieveCFragsSpy).toHaveBeenCalled();
     expect(bobPlaintext[0]).toEqual(plaintext);
   });
+
+  it('encrypts and decrypts reencrypted message from dynamic config 2', async () => {
+    const threshold = 3;
+    const shares = 5;
+    const label = 'test';
+    const startDate = new Date();
+    const endDate = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30); // In 30 days
+    const aliceSecretKey = SecretKey.random();
+    const provider = mockWeb3Provider(aliceSecretKey.toSecretBytes());
+
+    // Setup mocks for `generateTDecEntities`
+    const mockedUrsulas = mockUrsulas().slice(0, shares);
+    const getUrsulasSpy = mockGetUrsulas(mockedUrsulas);
+    const generateKFragsSpy = mockGenerateKFrags();
+    const publishToBlockchainSpy = mockPublishToBlockchain();
+    const makeTreasureMapSpy = mockMakeTreasureMap();
+    const encryptTreasureMapSpy = mockEncryptTreasureMap();
+
+    const [encrypter, decrypter, policy, config_json] = await generateTDecEntities(
+      threshold,
+      shares,
+      provider,
+      label,
+      startDate,
+      endDate,
+      'https://porter-ibex.nucypher.community',
+      aliceSecretKey
+    );
+
+    expect(policy.label).toBe(label);
+    expect(getUrsulasSpy).toHaveBeenCalled();
+    expect(generateKFragsSpy).toHaveBeenCalled();
+    expect(publishToBlockchainSpy).toHaveBeenCalled();
+    expect(encryptTreasureMapSpy).toHaveBeenCalled();
+    expect(makeTreasureMapSpy).toHaveBeenCalled();
+
+    const ownsBufficornNFT = new Conditions.ERC721Ownership({
+      contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
+      parameters: [3591],
+    });
+
+    const conditions = new ConditionSet([ownsBufficornNFT]);
+    encrypter.conditions = conditions;
+
+    const encryptedMessageKit = encrypter.encryptMessage(plaintext);
+
+    const bytes = encryptedMessageKit.toBytes();
+    expect(bytes).toContain(188); // the ESC delimter
+    const conditionbytes = ConditionsIntegrator.parse(bytes).conditionsBytes;
+
+    if (conditionbytes) {
+      const reconstituted = ConditionSet.fromBytes(conditionbytes);
+      expect(reconstituted.toList()[0].contractAddress).toEqual(
+        ownsBufficornNFT.value.contractAddress
+      );
+    }
+
+    // Setup mocks for `retrieveAndDecrypt`
+    const getUrsulasSpy2 = mockGetUrsulas(mockedUrsulas);
+    const ursulaAddresses = (
+      makeTreasureMapSpy.mock.calls[0][0] as readonly Ursula[]
+    ).map((u) => u.checksumAddress);
+    const verifiedKFrags = makeTreasureMapSpy.mock
+      .calls[0][1] as readonly VerifiedKeyFrag[];
+    const retrieveCFragsSpy = mockRetrieveCFragsRequest(
+      ursulaAddresses,
+      verifiedKFrags,
+      encryptedMessageKit.capsule
+    );
+
+    const bobPlaintext = await decrypter.retrieveAndDecrypt([
+      encryptedMessageKit,
+    ]);
+
+    expect(getUrsulasSpy2).toHaveBeenCalled();
+    expect(retrieveCFragsSpy).toHaveBeenCalled();
+    expect(bobPlaintext[0]).toEqual(plaintext);
+  });
+
 });

--- a/test/integration/tdec.test.ts
+++ b/test/integration/tdec.test.ts
@@ -1,7 +1,10 @@
 import { SecretKey, VerifiedKeyFrag } from '@nucypher/nucypher-core';
 
 import { Ursula } from '../../src/characters/porter';
-import { generateTDecEntities, TDecEntitiesFromConfig } from '../../src/characters/tDec';
+import {
+  generateTDecEntities,
+  TDecEntitiesFromConfig,
+} from '../../src/characters/tDec';
 import { ConditionsIntegrator } from '../../src/core';
 import { Conditions, ConditionSet } from '../../src/policies/conditions';
 import { toBytes } from '../../src/utils';
@@ -17,6 +20,10 @@ import {
 } from '../utils';
 
 describe('threshold decryption', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   const plaintext = toBytes('plaintext-message');
 
   it('encrypts and decrypts reencrypted message from dynamic config', async () => {
@@ -36,16 +43,17 @@ describe('threshold decryption', () => {
     const makeTreasureMapSpy = mockMakeTreasureMap();
     const encryptTreasureMapSpy = mockEncryptTreasureMap();
 
-    const [encrypter, decrypter, policy, config_json] = await generateTDecEntities(
-      threshold,
-      shares,
-      provider,
-      label,
-      startDate,
-      endDate,
-      'https://porter-ibex.nucypher.community',
-      aliceSecretKey
-    );
+    const [encrypter, decrypter, policy, config_json] =
+      await generateTDecEntities(
+        threshold,
+        shares,
+        provider,
+        label,
+        startDate,
+        endDate,
+        'https://porter-ibex.nucypher.community',
+        aliceSecretKey
+      );
 
     expect(policy.label).toBe(label);
     expect(getUrsulasSpy).toHaveBeenCalled();
@@ -97,7 +105,7 @@ describe('threshold decryption', () => {
     expect(bobPlaintext[0]).toEqual(plaintext);
   });
 
-  it('encrypts and decrypts reencrypted message from dynamic config 2', async () => {
+  it('encrypts and decrypts reencrypted message from json config', async () => {
     const threshold = 3;
     const shares = 5;
     const label = 'test';
@@ -114,16 +122,17 @@ describe('threshold decryption', () => {
     const makeTreasureMapSpy = mockMakeTreasureMap();
     const encryptTreasureMapSpy = mockEncryptTreasureMap();
 
-    const [encrypter, decrypter, policy, config_json] = await generateTDecEntities(
-      threshold,
-      shares,
-      provider,
-      label,
-      startDate,
-      endDate,
-      'https://porter-ibex.nucypher.community',
-      aliceSecretKey
-    );
+    const [encrypter, decrypter, policy, config_json] =
+      await generateTDecEntities(
+        threshold,
+        shares,
+        provider,
+        label,
+        startDate,
+        endDate,
+        'https://porter-ibex.nucypher.community',
+        aliceSecretKey
+      );
 
     expect(policy.label).toBe(label);
     expect(getUrsulasSpy).toHaveBeenCalled();
@@ -166,7 +175,12 @@ describe('threshold decryption', () => {
       encryptedMessageKit.capsule
     );
 
-    const bobPlaintext = await decrypter.retrieveAndDecrypt([
+    const [jsonEncrypter, jsonDecrypter] = await TDecEntitiesFromConfig(
+      config_json,
+      'https://porter-ibex.nucypher.community'
+    );
+
+    const bobPlaintext = await jsonDecrypter.retrieveAndDecrypt([
       encryptedMessageKit,
     ]);
 
@@ -174,5 +188,4 @@ describe('threshold decryption', () => {
     expect(retrieveCFragsSpy).toHaveBeenCalled();
     expect(bobPlaintext[0]).toEqual(plaintext);
   });
-
 });


### PR DESCRIPTION
When building tDec entities dynamically, the corresponding json configuration will be returned in addition to the constructed objects.
This json can be saved and used to rebuild those entities in the future.

Fixes https://github.com/nucypher/tdec/issues/41