### PR TITLE
Error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.7.9-alpha.15](https://github.com/nucypher/nucypher-ts/compare/v0.7.9-alpha.14...v0.7.9-alpha.15) (2022-09-23)
+
 ### [0.7.9-alpha.14](https://github.com/nucypher/nucypher-ts/compare/v0.7.9-alpha.12...v0.7.9-alpha.14) (2022-09-22)
 
 ### [0.7.9-alpha.13](https://github.com/nucypher/nucypher-ts/compare/v0.7.9-alpha.12...v0.7.9-alpha.13) (2022-09-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.7.9-alpha.14](https://github.com/nucypher/nucypher-ts/compare/v0.7.9-alpha.12...v0.7.9-alpha.14) (2022-09-22)
+
 ### [0.7.9-alpha.13](https://github.com/nucypher/nucypher-ts/compare/v0.7.9-alpha.12...v0.7.9-alpha.13) (2022-09-22)
 
 ### [0.7.9-alpha.12](https://github.com/nucypher/nucypher-ts/compare/v0.7.9-alpha.11...v0.7.9-alpha.12) (2022-09-15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.7.9-alpha.13](https://github.com/nucypher/nucypher-ts/compare/v0.7.9-alpha.12...v0.7.9-alpha.13) (2022-09-22)
+
 ### [0.7.9-alpha.12](https://github.com/nucypher/nucypher-ts/compare/v0.7.9-alpha.11...v0.7.9-alpha.12) (2022-09-15)
 
 ### [0.7.9-alpha.11](https://github.com/nucypher/nucypher-ts/compare/v0.7.9-alpha.10...v0.7.9-alpha.11) (2022-09-15)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nucypher/nucypher-ts",
   "author": "Piotr Roslaniec <p.roslaniec@gmail.com>",
-  "version": "0.7.9-alpha.13",
+  "version": "0.7.9-alpha.14",
   "license": "GPL-3.0-only",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nucypher/nucypher-ts",
   "author": "Piotr Roslaniec <p.roslaniec@gmail.com>",
-  "version": "0.7.9-alpha.14",
+  "version": "0.7.9-alpha.15",
   "license": "GPL-3.0-only",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nucypher/nucypher-ts",
   "author": "Piotr Roslaniec <p.roslaniec@gmail.com>",
-  "version": "0.7.9-alpha.12",
+  "version": "0.7.9-alpha.13",
   "license": "GPL-3.0-only",
   "repository": {
     "type": "git",

--- a/src/characters/bob.ts
+++ b/src/characters/bob.ts
@@ -88,7 +88,11 @@ export class Bob {
           const ursulasWithErrors = Object.entries(mk.errors).map(
             ([address, error]) => `${address} - ${error}`
           );
-          throw Error(`${errorMsg} Some Ursulas have failed with errors:\n${ursulasWithErrors.join('\n')}`);
+          throw Error(
+            `${errorMsg} Some Ursulas have failed with errors:\n${ursulasWithErrors.join(
+              '\n'
+            )}`
+          );
         } else {
           throw Error(errorMsg);
         }

--- a/src/characters/bob.ts
+++ b/src/characters/bob.ts
@@ -84,9 +84,11 @@ export class Bob {
     policyMessageKits.forEach((mk: PolicyMessageKit) => {
       if (!mk.isDecryptableByReceiver()) {
         const errorMsg = `Not enough cFrags retrieved to open capsule ${mk.capsule}.`;
-        const errors = Object.values(mk.errors);
-        if (errors.length > 0) {
-          throw Error(`${errorMsg} Errors:\n${errors.join('\n')}`);
+        if (Object.values(mk.errors).length > 0) {
+          const ursulasWithErrors = Object.entries(mk.errors).map(
+            ([address, error]) => `${address} - ${error}`
+          );
+          throw Error(`${errorMsg} Some Ursulas have failed with errors:\n${ursulasWithErrors.join('\n')}`);
         } else {
           throw Error(errorMsg);
         }

--- a/src/characters/porter.ts
+++ b/src/characters/porter.ts
@@ -50,6 +50,9 @@ type PostRetrieveCFragsResult = {
     readonly retrieval_results: readonly {
       readonly cfrags: {
         readonly [address: string]: string;
+      },
+      readonly errors: {
+        readonly [key: string]: string | Record<string, unknown>;
       };
     }[];
   };
@@ -114,6 +117,13 @@ export class Porter {
       new URL('/retrieve_cfrags', this.porterUrl).toString(),
       data
     );
+
+    resp.data.result.retrieval_results
+    .forEach((error: unknown) => {
+      // TODO: Handle errors from Porter
+      throw new Error(`${error}`);
+    });
+
     return resp.data.result.retrieval_results
       .map((result) => result.cfrags)
       .map((cFrags) => {

--- a/src/characters/universal-bob.ts
+++ b/src/characters/universal-bob.ts
@@ -60,7 +60,11 @@ export class tDecDecrypter {
           const ursulasWithErrors = Object.entries(mk.errors).map(
             ([address, error]) => `${address} - ${error}`
           );
-          throw Error(`${errorMsg} Some Ursulas have failed with errors:\n${ursulasWithErrors.join('\n')}`);
+          throw Error(
+            `${errorMsg} Some Ursulas have failed with errors:\n${ursulasWithErrors.join(
+              '\n'
+            )}`
+          );
         } else {
           throw Error(errorMsg);
         }

--- a/src/characters/universal-bob.ts
+++ b/src/characters/universal-bob.ts
@@ -56,9 +56,11 @@ export class tDecDecrypter {
     policyMessageKits.forEach((mk: PolicyMessageKit) => {
       if (!mk.isDecryptableByReceiver()) {
         const errorMsg = `Not enough cFrags retrieved to open capsule ${mk.capsule}.`;
-        const errors = Object.values(mk.errors);
-        if (errors.length > 0) {
-          throw Error(`${errorMsg} Errors:\n${errors.join('\n')}`);
+        if (Object.values(mk.errors).length > 0) {
+          const ursulasWithErrors = Object.entries(mk.errors).map(
+            ([address, error]) => `${address} - ${error}`
+          );
+          throw Error(`${errorMsg} Some Ursulas have failed with errors:\n${ursulasWithErrors.join('\n')}`);
         } else {
           throw Error(errorMsg);
         }

--- a/src/characters/universal-bob.ts
+++ b/src/characters/universal-bob.ts
@@ -53,11 +53,15 @@ export class tDecDecrypter {
       conditionContext
     );
 
-    policyMessageKits.forEach((mk) => {
+    policyMessageKits.forEach((mk: PolicyMessageKit) => {
       if (!mk.isDecryptableByReceiver()) {
-        throw Error(
-          `Not enough cFrags retrieved to open capsule ${mk.capsule}. Was the policy revoked?`
-        );
+        const errorMsg = `Not enough cFrags retrieved to open capsule ${mk.capsule}.`;
+        const errors = Object.values(mk.errors);
+        if (errors.length > 0) {
+          throw Error(`${errorMsg} Errors:\n${errors.join('\n')}`);
+        } else {
+          throw Error(errorMsg);
+        }
       }
     });
 
@@ -92,9 +96,9 @@ export class tDecDecrypter {
     );
 
     return zip(policyMessageKits, retrieveCFragsResponses).map((pair) => {
-      const [messageKit, cFragResponse] = pair;
-      const results = Object.keys(cFragResponse).map((address) => {
-        const verified = cFragResponse[address].verify(
+      const [messageKit, { cFrags, errors }] = pair;
+      const vcFrags = Object.keys(cFrags).map((address) => {
+        const verified = cFrags[address].verify(
           messageKit.capsule,
           this.publisherVerifyingKey,
           this.policyEncryptingKey,
@@ -102,7 +106,10 @@ export class tDecDecrypter {
         );
         return [address, verified];
       });
-      const retrievalResult = new RetrievalResult(Object.fromEntries(results));
+      const retrievalResult = new RetrievalResult(
+        Object.fromEntries(vcFrags),
+        errors
+      );
       return messageKit.withResult(retrievalResult);
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export { Porter } from './characters/porter';
 export { Keyring } from './keyring';
 export { Configuration, defaultConfiguration } from './config';
 export { RevocationKit } from './kits/revocation';
+export { PolicyMessageKit } from './kits/message';
 export {
   Conditions,
   ConditionSet,

--- a/src/kits/message.ts
+++ b/src/kits/message.ts
@@ -6,6 +6,8 @@ import {
   SecretKey,
 } from '@nucypher/nucypher-core';
 
+import { ChecksumAddress } from '../types';
+
 import { RetrievalResult } from './retrieval';
 
 export class PolicyMessageKit {
@@ -39,7 +41,7 @@ export class PolicyMessageKit {
   ): Uint8Array {
     const cFrags = Object.values(this.result.cFrags);
     if (!cFrags) {
-      throw 'Failed to attach any capsule fragments.';
+      throw Error('Failed to attach any capsule fragments.');
     }
 
     let mk = this.messageKit.withCFrag(cFrags[0]);
@@ -59,6 +61,10 @@ export class PolicyMessageKit {
       !!this.result.cFrags &&
       Object.keys(this.result.cFrags).length >= this.threshold
     );
+  }
+
+  public get errors(): Record<ChecksumAddress, string> {
+    return this.result.errors;
   }
 
   public toBytes(): Uint8Array {

--- a/src/kits/retrieval.ts
+++ b/src/kits/retrieval.ts
@@ -3,11 +3,10 @@ import { VerifiedCapsuleFrag } from '@nucypher/nucypher-core';
 import { ChecksumAddress } from '../types';
 
 export class RetrievalResult {
-  public readonly cFrags: Record<ChecksumAddress, VerifiedCapsuleFrag>;
-
-  constructor(cFrags?: Record<ChecksumAddress, VerifiedCapsuleFrag>) {
-    this.cFrags = cFrags ? cFrags : {};
-  }
+  constructor(
+    public readonly cFrags: Record<ChecksumAddress, VerifiedCapsuleFrag> = {},
+    public readonly errors: Record<ChecksumAddress, string> = {}
+  ) {}
 
   public static empty(): RetrievalResult {
     return new RetrievalResult();

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -155,9 +155,8 @@ export const mockCFragResponse = (
   const reencrypted = verifiedKFrags
     .map((kFrag) => reencrypt(capsule, kFrag))
     .map((cFrag) => CapsuleFrag.fromBytes(cFrag.toBytes()));
-  const result = Object.fromEntries(zip(ursulas, reencrypted));
-  // We return one result per capsule, so just one result
-  return [result];
+  const cFrags = Object.fromEntries(zip(ursulas, reencrypted));
+  return [{ cFrags, errors: {} }];
 };
 
 export const mockRetrieveCFragsRequest = (


### PR DESCRIPTION
- Adds error handling for Porter-related decryption failures
- `Bob.retrieveAndDecrypt` will throw a verbose error
- `Bob.retrieve` and `Bob.decrypt` offer a different workflow that enables custom error handling without throwing errors