### PR TITLE
Update schema validation & error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.7.9-alpha.18](https://github.com/nucypher/nucypher-ts/compare/v0.7.9-alpha.17...v0.7.9-alpha.18) (2022-09-30)
+
 ### [0.7.9-alpha.17](https://github.com/nucypher/nucypher-ts/compare/v0.7.9-alpha.16...v0.7.9-alpha.17) (2022-09-26)
 
 ### [0.7.9-alpha.16](https://github.com/nucypher/nucypher-ts/compare/v0.7.9-alpha.15...v0.7.9-alpha.16) (2022-09-26)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nucypher/nucypher-ts",
   "author": "Piotr Roslaniec <p.roslaniec@gmail.com>",
-  "version": "0.7.9-alpha.17",
+  "version": "0.7.9-alpha.18",
   "license": "GPL-3.0-only",
   "repository": {
     "type": "git",

--- a/src/policies/conditions.ts
+++ b/src/policies/conditions.ts
@@ -109,21 +109,20 @@ export class Condition {
     '!=',
   ];
   public static readonly SUPPORTED_CHAINS = [
-    'ethereum',
-    'rinkeby',
-    // 'polygon',
-    // 'mumbai'
+    // 'Rinkeby',
+    'Rinkeby',
+    // 'Polygon',
+    // 'Mumbai'
   ];
 
-  readonly schema = Joi.object();
+  public readonly schema = Joi.object();
   public readonly defaults = {};
-  public state = {};
-  public error: ValidationError | undefined;
-  public value: Record<string, unknown> = {};
+  private validationError?: ValidationError;
 
-  constructor(data: Record<string, unknown> = {}) {
-    const { value } = this.validate(data);
-    this.state = value;
+  constructor(private readonly value: Record<string, unknown> = {}) {}
+
+  public get error(): string | undefined {
+    return this.validationError?.message;
   }
 
   protected makeReturnValueTest() {
@@ -143,16 +142,13 @@ export class Condition {
     return value;
   }
 
-  public static fromObj(obj: Record<string, string>) {
+  public static fromObj(obj: Record<string, unknown>) {
     return new Condition(obj);
   }
 
   public validate(data: Record<string, unknown> = {}) {
-    this.state = Object.assign(this.defaults, this.state, data);
-    const { error, value } = this.schema.validate(this.state);
-    this.error = error;
-    this.value = value;
-    return { error, value };
+    const newValue = Object.assign(this.defaults, this.value, data);
+    return this.schema.validate(newValue);
   }
 
   public getContextParameters(): string[] {
@@ -311,7 +307,7 @@ class EvmCondition extends Condition {
 
 class ERC721Ownership extends EvmCondition {
   readonly defaults = {
-    chain: 'ethereum',
+    chain: 'Rinkeby',
     method: 'ownerOf',
     parameters: [],
     standardContractType: 'ERC721',
@@ -324,7 +320,7 @@ class ERC721Ownership extends EvmCondition {
 
 class ERC721Balance extends EvmCondition {
   readonly defaults = {
-    chain: 'ethereum',
+    chain: 'Rinkeby',
     method: 'balanceOf',
     parameters: [':userAddress'],
     standardContractType: 'ERC721',

--- a/test/integration/conditions.test.ts
+++ b/test/integration/conditions.test.ts
@@ -1,7 +1,11 @@
 import { SecretKey } from '@nucypher/nucypher-core';
 
-import { ConditionContext, Conditions, ConditionSet } from '../../src';
-import { Operator } from '../../src';
+import {
+  ConditionContext,
+  Conditions,
+  ConditionSet,
+  Operator,
+} from '../../src';
 import { Web3Provider } from '../../src/web3';
 import { mockWeb3Provider } from '../utils';
 
@@ -28,10 +32,10 @@ describe('conditions schema', () => {
     );
   });
 
-  result = condition.validate({ chain: 'ethereum' });
+  result = condition.validate({ chain: 'Rinkeby' });
   it('should update the value of "chain"', async () => {
     expect(result.error).toEqual(undefined);
-    expect(result.value.chain).toEqual('ethereum');
+    expect(result.value.chain).toEqual('Rinkeby');
   });
 });
 
@@ -52,14 +56,14 @@ describe('condition set', () => {
 
 describe('conditions set to/from json', () => {
   const json =
-    '[{"chain":"ethereum","method":"ownerOf","parameters":["3591"],"standardContractType":"ERC721","returnValueTest":{"comparator":"==","value":":userAddress"},"contractAddress":"0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77"}]';
-  const conditionset = ConditionSet.fromJSON(json);
+    '[{"chain":"Rinkeby","method":"ownerOf","parameters":["3591"],"standardContractType":"ERC721","returnValueTest":{"comparator":"==","value":":userAddress"},"contractAddress":"0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77"}]';
+  const conditionSet = ConditionSet.fromJSON(json);
 
   it('should be a ConditionSet', async () => {
-    expect(conditionset.conditions[0].toObj().contractAddress).toEqual(
+    expect(conditionSet.conditions[0].toObj().contractAddress).toEqual(
       '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77'
     );
-    expect(conditionset.toJson()).toEqual(json);
+    expect(conditionSet.toJson()).toEqual(json);
   });
 });
 
@@ -83,7 +87,7 @@ describe('conditions types', () => {
 
   it('rpc', async () => {
     const rpcCondition = {
-      chain: 'ethereum',
+      chain: 'Rinkeby',
       method: 'eth_getBalance',
       parameters: ['0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77'],
       returnValueTest,
@@ -95,7 +99,7 @@ describe('conditions types', () => {
   it('evm', async () => {
     const evmCondition = {
       contractAddress: '0x0000000000000000000000000000000000000000',
-      chain: 'ethereum',
+      chain: 'Rinkeby',
       standardContractType: 'ERC20',
       method: 'balanceOf',
       parameters: ['0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77'],
@@ -109,7 +113,7 @@ describe('conditions types', () => {
     const badEvmCondition = {
       // Intentionally removing `contractAddress`
       // contractAddress: '0x0000000000000000000000000000000000000000',
-      chain: 'ethereum',
+      chain: 'Rinkeby',
       standardContractType: 'ERC20',
       method: 'balanceOf',
       parameters: ['0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77'],
@@ -135,7 +139,7 @@ describe('produce context parameters from conditions', () => {
       contextParams.forEach((contextParam) => {
         it(`produces context parameter ${contextParam} for method ${method}`, () => {
           const rpcCondition = new Conditions.RpcCondition({
-            chain: 'ethereum',
+            chain: 'Rinkeby',
             method,
             parameters: [contextParam],
             returnValueTest: {
@@ -167,7 +171,7 @@ describe('produce context parameters from conditions', () => {
           it(`produces context parameter ${contextParam} for method ${method}`, () => {
             const evmCondition = new Conditions.EvmCondition({
               contractAddress: '0x0000000000000000000000000000000000000000',
-              chain: 'ethereum',
+              chain: 'Rinkeby',
               standardContractType: 'ERC20',
               method: 'balanceOf',
               parameters: [contextParam],
@@ -191,7 +195,7 @@ describe('condition context', () => {
     const web3Provider = Web3Provider.fromEthersWeb3Provider(provider);
 
     const rpcCondition = new Conditions.RpcCondition({
-      chain: 'ethereum',
+      chain: 'Rinkeby',
       method: 'eth_getBalance',
       parameters: [':userAddress'],
       returnValueTest: {

--- a/test/integration/conditions.test.ts
+++ b/test/integration/conditions.test.ts
@@ -1,7 +1,7 @@
 import { SecretKey } from '@nucypher/nucypher-core';
 
 import { ConditionContext, Conditions, ConditionSet } from '../../src';
-import { Operator } from '../../src/policies/conditions';
+import { Operator } from '../../src';
 import { Web3Provider } from '../../src/web3';
 import { mockWeb3Provider } from '../utils';
 
@@ -97,13 +97,29 @@ describe('conditions types', () => {
       contractAddress: '0x0000000000000000000000000000000000000000',
       chain: 'ethereum',
       standardContractType: 'ERC20',
-      functionAbi: 'missing',
       method: 'balanceOf',
       parameters: ['0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77'],
       returnValueTest,
     };
     const evm = new Conditions.EvmCondition(evmCondition);
     expect(evm.toObj()).toEqual(evmCondition);
+  });
+
+  it('malformed evm', async () => {
+    const badEvmCondition = {
+      // Intentionally removing `contractAddress`
+      // contractAddress: '0x0000000000000000000000000000000000000000',
+      chain: 'ethereum',
+      standardContractType: 'ERC20',
+      method: 'balanceOf',
+      parameters: ['0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77'],
+      returnValueTest,
+    };
+    const badCondition = new Conditions.EvmCondition(badEvmCondition);
+    expect(() => badCondition.toObj()).toThrow('"contractAddress" is required');
+
+    const { error } = badCondition.validate(badEvmCondition);
+    expect(error?.message).toEqual('"contractAddress" is required');
   });
 });
 
@@ -153,7 +169,6 @@ describe('produce context parameters from conditions', () => {
               contractAddress: '0x0000000000000000000000000000000000000000',
               chain: 'ethereum',
               standardContractType: 'ERC20',
-              functionAbi: 'missing',
               method: 'balanceOf',
               parameters: [contextParam],
               returnValueTest: {

--- a/test/integration/enrico.test.ts
+++ b/test/integration/enrico.test.ts
@@ -1,8 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Enrico } from '../../src';
-import { PolicyMessageKit } from '../../src/kits/message';
+import { Conditions, ConditionSet, Enrico, PolicyMessageKit } from '../../src';
 import { RetrievalResult } from '../../src/kits/retrieval';
-import { Conditions, ConditionSet } from '../../src/policies/conditions';
 import { toBytes } from '../../src/utils';
 import {
   bytesEqual,
@@ -92,7 +90,7 @@ describe('enrico', () => {
 
     const policyKey = alice.getPolicyEncryptingKeyFromLabel(label);
 
-    const ownsBufficornNFT = new Conditions.ERC721Ownership({
+    const ownsBufficornNFT = Conditions.ERC721Ownership.fromObj({
       contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
       parameters: [3591],
     });

--- a/test/integration/pre.test.ts
+++ b/test/integration/pre.test.ts
@@ -1,13 +1,14 @@
 import { CapsuleFrag, reencrypt } from '@nucypher/nucypher-core';
 
-import { Enrico, MessageKit } from '../../src';
-import { PolicyMessageKit } from '../../src/kits/message';
-import { RetrievalResult } from '../../src/kits/retrieval';
 import {
   Conditions,
   ConditionSet,
+  Enrico,
+  MessageKit,
   Operator,
-} from '../../src/policies/conditions';
+  PolicyMessageKit,
+} from '../../src';
+import { RetrievalResult } from '../../src/kits/retrieval';
 import { toBytes, zip } from '../../src/utils';
 import { mockAlice, mockBob, mockUrsulas, reencryptKFrags } from '../utils';
 


### PR DESCRIPTION
- `Condition.validate` method returns `{ error, ... }`, where `error` is an error type defined by `joi` 
- You can see an example of handling this `error` type [here](https://github.com/nucypher/nucypher-ts-demo-tdec/pull/9/files#diff-00accb80b3a014b9caba1977b32ca14a907ed6749856c2aba5d96e71c0301b3cR241-R246)