### PR TITLE
Remove unused `RevokedStrategy`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export {
 } from './conditions/condition-context';
 
 export { Cohort } from './sdk/cohort';
-export { DeployedStrategy, RevokedStrategy, Strategy } from './sdk/strategy';
+export { DeployedStrategy, Strategy } from './sdk/strategy';
 
 export {
   PublicKey,

--- a/src/sdk/strategy.ts
+++ b/src/sdk/strategy.ts
@@ -239,12 +239,3 @@ export class DeployedStrategy {
     };
   }
 }
-
-export class RevokedStrategy {
-  constructor(
-    public label: string,
-    public policy: EnactedPolicy,
-    public encrypter: Enrico,
-    public decrypter: tDecDecrypter
-  ) {}
-}


### PR DESCRIPTION
- Currently, the package exposes `RevokedStrategy`. However, no revocation functionality is available yet.
- This could be as source of confusion