### PR TITLE
Add class metadata to serialized conditions

### DIFF
--- a/src/conditions/base/condition.ts
+++ b/src/conditions/base/condition.ts
@@ -24,7 +24,10 @@ export class Condition {
     if (error) {
       throw `Invalid condition: ${error.message}`;
     }
-    return value;
+    return {
+      ...value,
+      _class: this.constructor.name,
+    };
   }
 
   public static fromObj<T extends Condition>(
@@ -33,6 +36,7 @@ export class Condition {
     this: new (...args: any[]) => T,
     obj: Map
   ): T {
+    delete obj._class;
     return new this(obj);
   }
 

--- a/test/unit/conditions/base/condition.test.ts
+++ b/test/unit/conditions/base/condition.test.ts
@@ -48,7 +48,10 @@ describe('validation', () => {
 describe('serialization', () => {
   it('serializes to a plain object', () => {
     const evm = new EvmCondition(testEvmConditionObj);
-    expect(evm.toObj()).toEqual(testEvmConditionObj);
+    expect(evm.toObj()).toEqual({
+      ...testEvmConditionObj,
+      _class: 'EvmCondition',
+    });
   });
 
   it('serializes predefined conditions', () => {
@@ -56,6 +59,7 @@ describe('serialization', () => {
     expect(evm.toObj()).toEqual({
       ...evm.defaults,
       ...testEvmConditionObj,
+      _class: 'ERC721Ownership',
     });
   });
 });

--- a/test/unit/conditions/base/evm.test.ts
+++ b/test/unit/conditions/base/evm.test.ts
@@ -4,7 +4,10 @@ import { testEvmConditionObj } from '../../testVariables';
 describe('validation', () => {
   it('accepts on a valid schema', () => {
     const evm = new EvmCondition(testEvmConditionObj);
-    expect(evm.toObj()).toEqual(testEvmConditionObj);
+    expect(evm.toObj()).toEqual({
+      ...testEvmConditionObj,
+      _class: 'EvmCondition',
+    });
   });
 
   it('rejects an invalid schema', () => {
@@ -34,7 +37,10 @@ describe('accepts either standardContractType or functionAbi but not both or non
       functionAbi: undefined,
     };
     const evmCondition = new EvmCondition(conditionObj);
-    expect(evmCondition.toObj()).toEqual(conditionObj);
+    expect(evmCondition.toObj()).toEqual({
+      ...conditionObj,
+      _class: 'EvmCondition',
+    });
   });
 
   it('accepts functionAbi', () => {
@@ -44,7 +50,10 @@ describe('accepts either standardContractType or functionAbi but not both or non
       standardContractType: undefined,
     };
     const evmCondition = new EvmCondition(conditionObj);
-    expect(evmCondition.toObj()).toEqual(conditionObj);
+    expect(evmCondition.toObj()).toEqual({
+      ...conditionObj,
+      _class: 'EvmCondition',
+    });
   });
 
   it('rejects both', () => {

--- a/test/unit/conditions/base/rpc.test.ts
+++ b/test/unit/conditions/base/rpc.test.ts
@@ -4,7 +4,10 @@ import { testRpcConditionObj } from '../../testVariables';
 describe('validation', () => {
   it('accepts on a valid schema', () => {
     const rpc = new RpcCondition(testRpcConditionObj);
-    expect(rpc.toObj()).toEqual(testRpcConditionObj);
+    expect(rpc.toObj()).toEqual({
+      ...testRpcConditionObj,
+      _class: 'RpcCondition',
+    });
   });
 
   it('rejects an invalid schema', () => {

--- a/test/unit/conditions/base/timelock.test.ts
+++ b/test/unit/conditions/base/timelock.test.ts
@@ -14,6 +14,7 @@ describe('validation', () => {
     expect(timelock.toObj()).toEqual({
       returnValueTest,
       method: 'timelock',
+      _class: 'TimelockCondition',
     });
   });
 


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:** 
- 1

**What this does:**
- Adds `_class` field to serialized `Condition` objects to indicate condition child class

**Issues fixed/closed:**
- Refers to #214

**Why it's needed:**
- Serialized conditions are not easily distinguishable
- This change allows for easier `Condition as MyCondition` casting

**Notes for reviewers:**
- This is a draft of one possible design to provide type casting to `Condition` consumers
