### PR TITLE
Remove TimeLockCondition object in favor of TimeCondition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [1.0.0-beta.1](https://github.com/nucypher/nucypher-ts/compare/v1.0.0-beta.0...v1.0.0-beta.1) (2023-03-27)
 
+### ⚠ BREAKING CHANGES
+* `TimeLockCondition` no longer supported; instead `TimeCondition` with method name `blocktime` can be used
 
 ### ⚠ BREAKING CHANGES
 

--- a/src/conditions/base/evm.ts
+++ b/src/conditions/base/evm.ts
@@ -10,6 +10,7 @@ export const STANDARD_CONTRACT_TYPES = ['ERC20', 'ERC721'];
 export class EvmCondition extends Condition {
   public readonly schema = Joi.object({
     contractAddress: Joi.string().pattern(ETH_ADDRESS_REGEXP).required(),
+    // TODO why is chain a string here?
     chain: Joi.string()
       .valid(...SUPPORTED_CHAINS)
       .required(),

--- a/src/conditions/base/index.ts
+++ b/src/conditions/base/index.ts
@@ -1,4 +1,4 @@
 export { Condition } from './condition';
 export { EvmCondition } from './evm';
 export { RpcCondition } from './rpc';
-export { TimelockCondition } from './timelock';
+export { TimeCondition } from './time';

--- a/src/conditions/base/time.ts
+++ b/src/conditions/base/time.ts
@@ -1,19 +1,24 @@
 import Joi from 'joi';
 
+import { SUPPORTED_CHAINS } from '../const';
+
 import { Condition } from './condition';
 import { returnValueTestSchema } from './schema';
 
-export class TimelockCondition extends Condition {
+export class TimeCondition extends Condition {
   // TODO: This is the only condition that uses defaults, and also the only condition that uses `method` in order
-  //   to determine the schema. I.e. the only method that used `METHOD = 'timelock'` in `nucypher/nucypher`.
+  //   to determine the schema. I.e. the only method that used `METHOD = 'blocktime'` in `nucypher/nucypher`.
   // TODO: Consider introducing a different field for this, e.g. `conditionType` or `type`. Use this field in a
   //  condition factory.
   public readonly defaults: Record<string, unknown> = {
-    method: 'timelock',
+    method: 'blocktime',
   };
 
   public readonly schema = Joi.object({
     method: Joi.string().valid(this.defaults.method).required(),
     returnValueTest: returnValueTestSchema.required(),
+    chain: Joi.number()
+      .valid(...SUPPORTED_CHAINS)
+      .required(),
   });
 }

--- a/test/unit/conditions/base/time.test.ts
+++ b/test/unit/conditions/base/time.test.ts
@@ -1,4 +1,4 @@
-import { TimelockCondition } from '../../../../src/conditions/base';
+import { TimeCondition } from '../../../../src/conditions/base';
 
 describe('validation', () => {
   const returnValueTest = {
@@ -8,31 +8,34 @@ describe('validation', () => {
   };
 
   it('accepts a valid schema', () => {
-    const timelock = new TimelockCondition({
+    const timeCondition = new TimeCondition({
       returnValueTest,
+      chain: 5,
     });
-    expect(timelock.toObj()).toEqual({
+    expect(timeCondition.toObj()).toEqual({
       returnValueTest,
-      method: 'timelock',
-      _class: 'TimelockCondition',
+      chain: 5,
+      method: 'blocktime',
+      _class: 'TimeCondition',
     });
   });
 
   it('rejects an invalid schema', () => {
-    const badTimelockObj = {
+    const badTimeObj = {
       // Intentionally replacing `returnValueTest` with an invalid test
       returnValueTest: {
         ...returnValueTest,
         comparator: 'not-a-comparator',
       },
+      chain: 5,
     };
 
-    const badTimelock = new TimelockCondition(badTimelockObj);
-    expect(() => badTimelock.toObj()).toThrow(
+    const badTimeCondition = new TimeCondition(badTimeObj);
+    expect(() => badTimeCondition.toObj()).toThrow(
       'Invalid condition: "returnValueTest.comparator" must be one of [==, >, <, >=, <=, !=]'
     );
 
-    const { error } = badTimelock.validate(badTimelockObj);
+    const { error } = badTimeCondition.validate(badTimeObj);
     expect(error?.message).toEqual(
       '"returnValueTest.comparator" must be one of [==, >, <, >=, <=, !=]'
     );


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

**Required reviews:** 
> How many reviews does the PR author need?
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Update `nucypher-ts` based on changes performed in `nucypher` - https://github.com/nucypher/nucypher/pull/3139.

TimeLockCondition is now removed in favor of TimeCondition with method name "blocktime" , and takes a chain id value.

**Issues fixed/closed:**
> - Fixes #...

Fixes #217.

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?

Hopefully I got everything 🤞 .