### PR TITLE
Add a convenience method for creating encrypters #125

### DIFF
--- a/src/characters/cbd-recipient.ts
+++ b/src/characters/cbd-recipient.ts
@@ -5,7 +5,6 @@ import {
   DecryptionShareSimple,
   decryptWithSharedSecret,
   DkgPublicParameters,
-  SharedSecret,
   EncryptedThresholdDecryptionRequest,
   EncryptedThresholdDecryptionResponse,
   SessionSharedSecret,
@@ -40,15 +39,15 @@ export class CbdTDecDecrypter {
     private readonly porter: Porter,
     private readonly ritualId: number,
     private readonly dkgPublicParams: DkgPublicParameters,
-    private readonly  threshold: number
+    private readonly threshold: number
   ) {}
 
-  public static create(porterUri: string, dkgRitual: DkgRitual, threshold: number) {
+  public static create(porterUri: string, dkgRitual: DkgRitual) {
     return new CbdTDecDecrypter(
       new Porter(porterUri),
       dkgRitual.id,
       dkgRitual.dkgPublicParams,
-      threshold,
+      dkgRitual.threshold
     );
   }
 
@@ -63,7 +62,6 @@ export class CbdTDecDecrypter {
     const decryptionShares = await this.retrieve(
       provider,
       conditionSet,
-      this.ritualId,
       variant,
       ciphertext
     );
@@ -85,17 +83,16 @@ export class CbdTDecDecrypter {
   public async retrieve(
     provider: ethers.providers.Web3Provider,
     conditionSet: ConditionSet,
-    ritualId: number,
     variant: number,
     ciphertext: Ciphertext
   ): Promise<DecryptionSharePrecomputed[] | DecryptionShareSimple[]> {
     const dkgParticipants = await DkgCoordinatorAgent.getParticipants(
       provider,
-      ritualId
+      this.ritualId
     );
     const contextStr = await conditionSet.buildContext(provider).toJson();
     const { sharedSecrets, encryptedRequests } = this.makeDecryptionRequests(
-      ritualId,
+      this.ritualId,
       variant,
       ciphertext,
       conditionSet,
@@ -117,7 +114,7 @@ export class CbdTDecDecrypter {
       encryptedResponses,
       sharedSecrets,
       variant,
-      ritualId
+      this.ritualId
     );
   }
 

--- a/src/characters/pre-recipient.ts
+++ b/src/characters/pre-recipient.ts
@@ -16,7 +16,7 @@ import { base64ToU8Receiver, bytesEquals, toJSON, zip } from '../utils';
 
 import { Porter } from './porter';
 
-type PreTDecDecrypterJSON = {
+export type PreTDecDecrypterJSON = {
   porterUri: string;
   policyEncryptingKeyBytes: Uint8Array;
   encryptedTreasureMapBytes: Uint8Array;
@@ -25,22 +25,30 @@ type PreTDecDecrypterJSON = {
 };
 
 export class PreTDecDecrypter {
-  private readonly porter: Porter;
-  private readonly keyring: Keyring;
-
   // private readonly verifyingKey: Keyring;
 
   constructor(
-    porterUri: string,
+    private readonly porter: Porter,
+    private readonly keyring: Keyring,
     private readonly policyEncryptingKey: PublicKey,
-    readonly encryptedTreasureMap: EncryptedTreasureMap,
     private readonly publisherVerifyingKey: PublicKey,
-    secretKey: SecretKey
-    // verifyingKey: SecretKey
-  ) {
-    this.porter = new Porter(porterUri);
-    this.keyring = new Keyring(secretKey);
-    // this.verifyingKey = new Keyring(verifyingKey);
+    private readonly encryptedTreasureMap: EncryptedTreasureMap
+  ) {}
+
+  public static create(
+    porterUri: string,
+    secretKey: SecretKey,
+    policyEncryptingKey: PublicKey,
+    publisherVerifyingKey: PublicKey,
+    encryptedTreasureMap: EncryptedTreasureMap
+  ): PreTDecDecrypter {
+    return new PreTDecDecrypter(
+      new Porter(porterUri),
+      new Keyring(secretKey),
+      policyEncryptingKey,
+      publisherVerifyingKey,
+      encryptedTreasureMap
+    );
   }
 
   public get decryptingKey(): PublicKey {
@@ -161,11 +169,11 @@ export class PreTDecDecrypter {
     bobSecretKeyBytes,
   }: PreTDecDecrypterJSON) {
     return new PreTDecDecrypter(
-      porterUri,
+      new Porter(porterUri),
+      new Keyring(SecretKey.fromBEBytes(bobSecretKeyBytes)),
       PublicKey.fromCompressedBytes(policyEncryptingKeyBytes),
-      EncryptedTreasureMap.fromBytes(encryptedTreasureMapBytes),
       PublicKey.fromCompressedBytes(publisherVerifyingKeyBytes),
-      SecretKey.fromBEBytes(bobSecretKeyBytes)
+      EncryptedTreasureMap.fromBytes(encryptedTreasureMapBytes)
     );
   }
 

--- a/src/dkg.ts
+++ b/src/dkg.ts
@@ -29,6 +29,7 @@ export function getVariantClass(
       throw new Error(`Invalid FerveoVariant: ${variant}`);
   }
 }
+
 export function getCombineDecryptionSharesFunction(
   variant: FerveoVariant
 ): (
@@ -48,13 +49,15 @@ export interface DkgRitualJSON {
   id: number;
   dkgPublicKey: Uint8Array;
   dkgPublicParams: Uint8Array;
+  threshold: number;
 }
 
 export class DkgRitual {
   constructor(
     public readonly id: number,
     public readonly dkgPublicKey: DkgPublicKey,
-    public readonly dkgPublicParams: DkgPublicParameters
+    public readonly dkgPublicParams: DkgPublicParameters,
+    public readonly threshold: number
   ) {}
 
   public toObj(): DkgRitualJSON {
@@ -62,14 +65,21 @@ export class DkgRitual {
       id: this.id,
       dkgPublicKey: this.dkgPublicKey.toBytes(),
       dkgPublicParams: this.dkgPublicParams.toBytes(),
+      threshold: this.threshold,
     };
   }
 
-  public static fromObj(json: DkgRitualJSON): DkgRitual {
+  public static fromObj({
+    id,
+    dkgPublicKey,
+    dkgPublicParams,
+    threshold,
+  }: DkgRitualJSON): DkgRitual {
     return new DkgRitual(
-      json.id,
-      DkgPublicKey.fromBytes(json.dkgPublicKey),
-      DkgPublicParameters.fromBytes(json.dkgPublicParams)
+      id,
+      DkgPublicKey.fromBytes(dkgPublicKey),
+      DkgPublicParameters.fromBytes(dkgPublicParams),
+      threshold
     );
   }
 

--- a/src/policies/policy.ts
+++ b/src/policies/policy.ts
@@ -11,7 +11,6 @@ import { PreSubscriptionManagerAgent } from '../agents/subscription-manager';
 import { Alice } from '../characters/alice';
 import { RemoteBob } from '../characters/bob';
 import { Ursula } from '../characters/porter';
-// import { RevocationKit } from '../kits/revocation';
 import { toBytes, toEpoch, zip } from '../utils';
 import { toCanonicalAddress } from '../web3';
 
@@ -20,8 +19,7 @@ export type EnactedPolicy = {
   readonly label: string;
   readonly policyKey: PublicKey;
   readonly encryptedTreasureMap: EncryptedTreasureMap;
-  // readonly revocationKit: RevocationKit;
-  readonly aliceVerifyingKey: Uint8Array;
+  readonly aliceVerifyingKey: PublicKey;
   readonly size: number;
   readonly startTimestamp: Date;
   readonly endTimestamp: Date;
@@ -45,8 +43,7 @@ export class PreEnactedPolicy implements IPreEnactedPolicy {
     public readonly label: string,
     public readonly policyKey: PublicKey,
     public readonly encryptedTreasureMap: EncryptedTreasureMap,
-    // public readonly revocationKit: RevocationKit,
-    public readonly aliceVerifyingKey: Uint8Array,
+    public readonly aliceVerifyingKey: PublicKey,
     public readonly size: number,
     public readonly startTimestamp: Date,
     public readonly endTimestamp: Date
@@ -130,8 +127,7 @@ export class BlockchainPolicy {
       this.label,
       this.delegatingKey,
       encryptedTreasureMap,
-      // revocationKit,
-      this.publisher.verifyingKey.toCompressedBytes(),
+      this.publisher.verifyingKey,
       this.shares,
       this.startDate,
       this.endDate

--- a/src/sdk/strategy/cbd-strategy.ts
+++ b/src/sdk/strategy/cbd-strategy.ts
@@ -93,13 +93,17 @@ export class CbdStrategy {
 }
 
 export class DeployedCbdStrategy {
-  constructor(
+  public constructor(
     public readonly cohort: Cohort,
     public readonly dkgRitual: DkgRitual,
     public readonly encrypter: Enrico,
     public readonly decrypter: CbdTDecDecrypter,
     public readonly conditionSet?: ConditionSet
   ) {}
+
+  public makeEncrypter(conditionSet: ConditionSet): Enrico {
+    return new Enrico(this.dkgRitual.dkgPublicKey, undefined, conditionSet);
+  }
 
   public static fromJSON(json: string) {
     const config = fromJSON(json);

--- a/src/sdk/strategy/pre-strategy.ts
+++ b/src/sdk/strategy/pre-strategy.ts
@@ -180,15 +180,19 @@ export class PreStrategy {
 }
 
 export class DeployedPreStrategy {
-  constructor(
-    public label: string,
-    public cohort: Cohort,
-    public policy: EnactedPolicy,
-    public encrypter: Enrico,
-    public decrypter: PreTDecDecrypter,
-    private bobSecretKey: SecretKey,
-    public conditionSet?: ConditionSet
+  public constructor(
+    public readonly label: string,
+    public readonly cohort: Cohort,
+    public readonly policy: EnactedPolicy,
+    public readonly encrypter: Enrico,
+    public readonly decrypter: PreTDecDecrypter,
+    private readonly bobSecretKey: SecretKey,
+    public readonly conditionSet?: ConditionSet
   ) {}
+
+  public makeEncrypter(conditionSet: ConditionSet): Enrico {
+    return new Enrico(this.policy.policyKey, undefined, conditionSet);
+  }
 
   public static fromJSON(json: string) {
     const config = JSON.parse(json, base64ToU8Receiver);

--- a/src/sdk/strategy/pre-strategy.ts
+++ b/src/sdk/strategy/pre-strategy.ts
@@ -1,17 +1,15 @@
-import {
-  EncryptedTreasureMap,
-  HRAC,
-  PublicKey,
-  SecretKey,
-} from '@nucypher/nucypher-core';
+import { PublicKey, SecretKey } from '@nucypher/nucypher-core';
 import { ethers } from 'ethers';
 
 import { Alice } from '../../characters/alice';
 import { Bob } from '../../characters/bob';
 import { Enrico } from '../../characters/enrico';
-import { PreTDecDecrypter } from '../../characters/pre-recipient';
-import { ConditionSet, ConditionSetJSON } from '../../conditions';
-import { EnactedPolicy, EnactedPolicyJSON } from '../../policies/policy';
+import {
+  PreTDecDecrypter,
+  PreTDecDecrypterJSON,
+} from '../../characters/pre-recipient';
+import { ConditionSet } from '../../conditions';
+import { EnactedPolicy } from '../../policies/policy';
 import { base64ToU8Receiver, bytesEquals, toJSON } from '../../utils';
 import { Cohort, CohortJSON } from '../cohort';
 
@@ -19,16 +17,15 @@ export type PreStrategyJSON = {
   cohort: CohortJSON;
   aliceSecretKeyBytes: Uint8Array;
   bobSecretKeyBytes: Uint8Array;
-  conditionSet?: ConditionSetJSON;
   startDate: Date;
   endDate: Date;
 };
 
 export type DeployedPreStrategyJSON = {
-  policy: EnactedPolicyJSON;
   cohortConfig: CohortJSON;
   bobSecretKeyBytes: Uint8Array;
-  conditionSet?: ConditionSetJSON;
+  decrypterJSON: PreTDecDecrypterJSON;
+  policyKeyBytes: Uint8Array;
 };
 
 export class PreStrategy {
@@ -37,13 +34,11 @@ export class PreStrategy {
     private readonly aliceSecretKey: SecretKey,
     private readonly bobSecretKey: SecretKey,
     private readonly startDate: Date,
-    private readonly endDate: Date,
-    private readonly conditionSet?: ConditionSet
+    private readonly endDate: Date
   ) {}
 
   public static create(
     cohort: Cohort,
-    conditionSet?: ConditionSet,
     aliceSecretKey?: SecretKey,
     bobSecretKey?: SecretKey,
     startDate?: Date,
@@ -66,8 +61,7 @@ export class PreStrategy {
       aliceSecretKey,
       bobSecretKey,
       startDate,
-      endDate,
-      conditionSet
+      endDate
     );
   }
 
@@ -92,22 +86,7 @@ export class PreStrategy {
       endDate: this.endDate,
     };
     const policy = await alice.grant(policyParams, this.cohort.ursulaAddresses);
-
-    const decrypter = new PreTDecDecrypter(
-      this.cohort.configuration.porterUri,
-      policy.policyKey,
-      policy.encryptedTreasureMap,
-      alice.verifyingKey,
-      this.bobSecretKey
-    );
-    return new DeployedPreStrategy(
-      label,
-      this.cohort,
-      policy,
-      decrypter,
-      this.bobSecretKey,
-      this.conditionSet
-    );
+    return DeployedPreStrategy.create(this.cohort, policy, this.bobSecretKey);
   }
 
   public static fromJSON(json: string) {
@@ -125,7 +104,6 @@ export class PreStrategy {
     cohort,
     aliceSecretKeyBytes,
     bobSecretKeyBytes,
-    conditionSet,
     startDate,
     endDate,
   }: PreStrategyJSON) {
@@ -134,8 +112,7 @@ export class PreStrategy {
       SecretKey.fromBEBytes(aliceSecretKeyBytes),
       SecretKey.fromBEBytes(bobSecretKeyBytes),
       new Date(startDate),
-      new Date(endDate),
-      conditionSet ? ConditionSet.fromObj(conditionSet) : undefined
+      new Date(endDate)
     );
   }
 
@@ -144,17 +121,12 @@ export class PreStrategy {
       cohort: this.cohort.toObj(),
       aliceSecretKeyBytes: this.aliceSecretKey.toBEBytes(),
       bobSecretKeyBytes: this.bobSecretKey.toBEBytes(),
-      conditionSet: this.conditionSet ? this.conditionSet.toObj() : undefined,
       startDate: this.startDate,
       endDate: this.endDate,
     };
   }
 
   public equals(other: PreStrategy) {
-    const conditionSetEquals =
-      this.conditionSet && other.conditionSet
-        ? this.conditionSet.equals(other.conditionSet)
-        : this.conditionSet === other.conditionSet;
     return (
       this.cohort.equals(other.cohort) &&
       // TODO: Add equality to WASM bindings
@@ -166,7 +138,6 @@ export class PreStrategy {
         this.bobSecretKey.toBEBytes(),
         other.bobSecretKey.toBEBytes()
       ) &&
-      conditionSetEquals &&
       this.startDate.toString() === other.startDate.toString() &&
       this.endDate.toString() === other.endDate.toString()
     );
@@ -174,17 +145,35 @@ export class PreStrategy {
 }
 
 export class DeployedPreStrategy {
-  public constructor(
-    public readonly label: string,
+  private constructor(
     public readonly cohort: Cohort,
-    public readonly policy: EnactedPolicy,
-    public readonly decrypter: PreTDecDecrypter,
     private readonly bobSecretKey: SecretKey,
-    public readonly conditionSet?: ConditionSet
+    public readonly decrypter: PreTDecDecrypter,
+    public readonly policyKey: PublicKey
   ) {}
 
+  public static create(
+    cohort: Cohort,
+    policy: EnactedPolicy,
+    bobSecretKey: SecretKey
+  ) {
+    const decrypter = PreTDecDecrypter.create(
+      cohort.configuration.porterUri,
+      bobSecretKey,
+      policy.policyKey,
+      policy.aliceVerifyingKey,
+      policy.encryptedTreasureMap
+    );
+    return new DeployedPreStrategy(
+      cohort,
+      bobSecretKey,
+      decrypter,
+      policy.policyKey
+    );
+  }
+
   public makeEncrypter(conditionSet: ConditionSet): Enrico {
-    return new Enrico(this.policy.policyKey, undefined, conditionSet);
+    return new Enrico(this.policyKey, undefined, conditionSet);
   }
 
   public static fromJSON(json: string) {
@@ -197,86 +186,39 @@ export class DeployedPreStrategy {
   }
 
   public static fromObj({
-    policy,
     cohortConfig,
     bobSecretKeyBytes,
-    conditionSet,
+    decrypterJSON,
+    policyKeyBytes,
   }: DeployedPreStrategyJSON) {
-    const id = HRAC.fromBytes(policy.id);
-    const policyKey = PublicKey.fromCompressedBytes(policy.policyKey);
-    const encryptedTreasureMap = EncryptedTreasureMap.fromBytes(
-      policy.encryptedTreasureMap
-    );
-    const aliceVerifyingKey = PublicKey.fromCompressedBytes(
-      policy.aliceVerifyingKey
-    );
-    const newPolicy = {
-      id,
-      label: policy.label,
-      policyKey,
-      encryptedTreasureMap,
-      aliceVerifyingKey: aliceVerifyingKey.toCompressedBytes(),
-      size: policy.size,
-      startTimestamp: policy.startTimestamp,
-      endTimestamp: policy.endTimestamp,
-      txHash: policy.txHash,
-    };
-    const bobSecretKey = SecretKey.fromBEBytes(bobSecretKeyBytes);
-    const label = newPolicy.label;
     const cohort = Cohort.fromObj(cohortConfig);
-
-    const conditionSetOrUndefined = conditionSet
-      ? ConditionSet.fromObj(conditionSet)
-      : undefined;
-
-    const decrypter = new PreTDecDecrypter(
-      cohort.configuration.porterUri,
-      policyKey,
-      encryptedTreasureMap,
-      aliceVerifyingKey,
-      bobSecretKey
-    );
-    return new DeployedPreStrategy(
-      label,
-      cohort,
-      newPolicy,
-      decrypter,
-      bobSecretKey,
-      conditionSetOrUndefined
-    );
+    const bobSecretKey = SecretKey.fromBEBytes(bobSecretKeyBytes);
+    const decrypter = PreTDecDecrypter.fromObj(decrypterJSON);
+    const policyKey = PublicKey.fromCompressedBytes(policyKeyBytes);
+    return new DeployedPreStrategy(cohort, bobSecretKey, decrypter, policyKey);
   }
 
   public toObj(): DeployedPreStrategyJSON {
-    const policy = {
-      ...this.policy,
-      id: this.policy.id.toBytes(),
-      policyKey: this.policy.policyKey.toCompressedBytes(),
-      encryptedTreasureMap: this.policy.encryptedTreasureMap.toBytes(),
-    };
     return {
-      policy,
       cohortConfig: this.cohort.toObj(),
       bobSecretKeyBytes: this.bobSecretKey.toBEBytes(),
-      conditionSet: this.conditionSet?.toObj(),
+      decrypterJSON: this.decrypter.toObj(),
+      policyKeyBytes: this.policyKey.toCompressedBytes(),
     };
   }
 
   public equals(other: DeployedPreStrategy) {
-    const conditionSetEquals =
-      this.conditionSet && other.conditionSet
-        ? this.conditionSet.equals(other.conditionSet)
-        : this.conditionSet === other.conditionSet;
     return (
-      this.label === other.label &&
       this.cohort.equals(other.cohort) &&
-      bytesEquals(this.policy.id.toBytes(), other.policy.id.toBytes()) &&
-      this.policy.label === other.policy.label &&
-      this.policy.policyKey.equals(other.policy.policyKey) &&
       bytesEquals(
-        this.policy.encryptedTreasureMap.toBytes(),
-        other.policy.encryptedTreasureMap.toBytes()
+        this.bobSecretKey.toBEBytes(),
+        other.bobSecretKey.toBEBytes()
       ) &&
-      conditionSetEquals
+      this.decrypter.equals(other.decrypter) &&
+      bytesEquals(
+        this.policyKey.toCompressedBytes(),
+        other.policyKey.toCompressedBytes()
+      )
     );
   }
 }

--- a/src/sdk/strategy/pre-strategy.ts
+++ b/src/sdk/strategy/pre-strategy.ts
@@ -23,7 +23,6 @@ export type PreStrategyJSON = {
 
 export type DeployedPreStrategyJSON = {
   cohortConfig: CohortJSON;
-  bobSecretKeyBytes: Uint8Array;
   decrypterJSON: PreTDecDecrypterJSON;
   policyKeyBytes: Uint8Array;
 };
@@ -147,7 +146,6 @@ export class PreStrategy {
 export class DeployedPreStrategy {
   private constructor(
     public readonly cohort: Cohort,
-    private readonly bobSecretKey: SecretKey,
     public readonly decrypter: PreTDecDecrypter,
     public readonly policyKey: PublicKey
   ) {}
@@ -164,12 +162,7 @@ export class DeployedPreStrategy {
       policy.aliceVerifyingKey,
       policy.encryptedTreasureMap
     );
-    return new DeployedPreStrategy(
-      cohort,
-      bobSecretKey,
-      decrypter,
-      policy.policyKey
-    );
+    return new DeployedPreStrategy(cohort, decrypter, policy.policyKey);
   }
 
   public makeEncrypter(conditionSet: ConditionSet): Enrico {
@@ -187,21 +180,18 @@ export class DeployedPreStrategy {
 
   public static fromObj({
     cohortConfig,
-    bobSecretKeyBytes,
     decrypterJSON,
     policyKeyBytes,
   }: DeployedPreStrategyJSON) {
     const cohort = Cohort.fromObj(cohortConfig);
-    const bobSecretKey = SecretKey.fromBEBytes(bobSecretKeyBytes);
     const decrypter = PreTDecDecrypter.fromObj(decrypterJSON);
     const policyKey = PublicKey.fromCompressedBytes(policyKeyBytes);
-    return new DeployedPreStrategy(cohort, bobSecretKey, decrypter, policyKey);
+    return new DeployedPreStrategy(cohort, decrypter, policyKey);
   }
 
   public toObj(): DeployedPreStrategyJSON {
     return {
       cohortConfig: this.cohort.toObj(),
-      bobSecretKeyBytes: this.bobSecretKey.toBEBytes(),
       decrypterJSON: this.decrypter.toObj(),
       policyKeyBytes: this.policyKey.toCompressedBytes(),
     };
@@ -210,10 +200,6 @@ export class DeployedPreStrategy {
   public equals(other: DeployedPreStrategy) {
     return (
       this.cohort.equals(other.cohort) &&
-      bytesEquals(
-        this.bobSecretKey.toBEBytes(),
-        other.bobSecretKey.toBEBytes()
-      ) &&
       this.decrypter.equals(other.decrypter) &&
       bytesEquals(
         this.policyKey.toCompressedBytes(),

--- a/src/sdk/strategy/pre-strategy.ts
+++ b/src/sdk/strategy/pre-strategy.ts
@@ -92,11 +92,6 @@ export class PreStrategy {
       endDate: this.endDate,
     };
     const policy = await alice.grant(policyParams, this.cohort.ursulaAddresses);
-    const encrypter = new Enrico(
-      policy.policyKey,
-      undefined,
-      this.conditionSet
-    );
 
     const decrypter = new PreTDecDecrypter(
       this.cohort.configuration.porterUri,
@@ -109,7 +104,6 @@ export class PreStrategy {
       label,
       this.cohort,
       policy,
-      encrypter,
       decrypter,
       this.bobSecretKey,
       this.conditionSet
@@ -184,7 +178,6 @@ export class DeployedPreStrategy {
     public readonly label: string,
     public readonly cohort: Cohort,
     public readonly policy: EnactedPolicy,
-    public readonly encrypter: Enrico,
     public readonly decrypter: PreTDecDecrypter,
     private readonly bobSecretKey: SecretKey,
     public readonly conditionSet?: ConditionSet
@@ -235,11 +228,6 @@ export class DeployedPreStrategy {
     const conditionSetOrUndefined = conditionSet
       ? ConditionSet.fromObj(conditionSet)
       : undefined;
-    const encrypter = new Enrico(
-      newPolicy.policyKey,
-      undefined,
-      conditionSetOrUndefined
-    );
 
     const decrypter = new PreTDecDecrypter(
       cohort.configuration.porterUri,
@@ -252,7 +240,6 @@ export class DeployedPreStrategy {
       label,
       cohort,
       newPolicy,
-      encrypter,
       decrypter,
       bobSecretKey,
       conditionSetOrUndefined

--- a/test/acceptance/alice-grants.test.ts
+++ b/test/acceptance/alice-grants.test.ts
@@ -64,9 +64,12 @@ describe('story: alice shares message with bob through policy', () => {
     };
     policy = await alice.grant(policyParams);
 
-    expect(policy.aliceVerifyingKey).toEqual(
-      alice.verifyingKey.toCompressedBytes()
-    );
+    expect(
+      bytesEqual(
+        policy.aliceVerifyingKey.toCompressedBytes(),
+        alice.verifyingKey.toCompressedBytes()
+      )
+    ).toBeTruthy();
     expect(policy.label).toBe(label);
     expect(getUrsulasSpy).toHaveBeenCalled();
     expect(generateKFragsSpy).toHaveBeenCalled();

--- a/test/acceptance/delay-enact.test.ts
+++ b/test/acceptance/delay-enact.test.ts
@@ -1,4 +1,5 @@
 import {
+  bytesEqual,
   fakeAlice,
   fakeRemoteBob,
   fakeUrsulas,
@@ -37,9 +38,12 @@ describe('story: alice1 creates a policy but alice2 enacts it', () => {
     const preEnactedPolicy = await alice1.generatePreEnactedPolicy(
       policyParams
     );
-    expect(preEnactedPolicy.aliceVerifyingKey).toEqual(
-      alice1.verifyingKey.toCompressedBytes()
-    );
+    expect(
+      bytesEqual(
+        preEnactedPolicy.aliceVerifyingKey.toCompressedBytes(),
+        alice1.verifyingKey.toCompressedBytes()
+      )
+    ).toBeTruthy();
     expect(preEnactedPolicy.label).toBe(label);
 
     const enacted = await preEnactedPolicy.enact(alice2);

--- a/test/docs/cbd.test.ts
+++ b/test/docs/cbd.test.ts
@@ -103,9 +103,8 @@ describe('Get Started (CBD PoC)', () => {
     const NFTBalance = new ContractCondition(NFTBalanceConfig);
     const newConditions = new ConditionSet([NFTBalance]);
     const plaintext = 'this is a secret';
-    const encryptedMessageKit = newDeployed
-      .makeEncrypter(newConditions)
-      .encryptMessagePre(plaintext);
+    const encrypter = newDeployed.makeEncrypter(newConditions);
+    const encryptedMessageKit = encrypter.encryptMessagePre(plaintext);
 
     // Mocking - Not a part of any code example
     const retrieveCFragsSpy = mockRetrieveAndDecrypt(

--- a/test/docs/cbd.test.ts
+++ b/test/docs/cbd.test.ts
@@ -101,12 +101,11 @@ describe('Get Started (CBD PoC)', () => {
       },
     };
     const NFTBalance = new ContractCondition(NFTBalanceConfig);
-
+    const newConditions = new ConditionSet([NFTBalance]);
     const plaintext = 'this is a secret';
-    const encryptedMessageKit = newDeployed.encrypter.encryptMessagePre(
-      plaintext,
-      new ConditionSet([NFTBalance])
-    );
+    const encryptedMessageKit = newDeployed
+      .makeEncrypter(newConditions)
+      .encryptMessagePre(plaintext);
 
     // Mocking - Not a part of any code example
     const retrieveCFragsSpy = mockRetrieveAndDecrypt(

--- a/test/docs/cbd.test.ts
+++ b/test/docs/cbd.test.ts
@@ -102,10 +102,8 @@ describe('Get Started (CBD PoC)', () => {
     };
     const NFTBalance = new ContractCondition(NFTBalanceConfig);
 
-    const encrypter = newDeployed.encrypter;
-
     const plaintext = 'this is a secret';
-    const encryptedMessageKit = encrypter.encryptMessagePre(
+    const encryptedMessageKit = newDeployed.encrypter.encryptMessagePre(
       plaintext,
       new ConditionSet([NFTBalance])
     );

--- a/test/docs/cbd.test.ts
+++ b/test/docs/cbd.test.ts
@@ -80,7 +80,7 @@ describe('Get Started (CBD PoC)', () => {
     ]);
 
     // 4. Build a Strategy
-    const newStrategy = PreStrategy.create(newCohort, conditions);
+    const newStrategy = PreStrategy.create(newCohort);
 
     const MMprovider = await detectEthereumProvider();
     const mumbai = providers.getNetwork(80001);
@@ -133,7 +133,6 @@ describe('Get Started (CBD PoC)', () => {
     );
     expect(conditions.validate()).toEqual(true);
     expect(publishToBlockchainSpy).toHaveBeenCalled();
-    expect(newDeployed.label).toEqual('test');
     expect(getUrsulasSpy).toHaveBeenCalledTimes(2);
     expect(generateKFragsSpy).toHaveBeenCalled();
     expect(encryptTreasureMapSpy).toHaveBeenCalled();

--- a/test/unit/cbd-strategy.test.ts
+++ b/test/unit/cbd-strategy.test.ts
@@ -44,7 +44,7 @@ const variant = FerveoVariant.Precomputed;
 
 const makeCbdStrategy = async () => {
   const cohort = await makeCohort(ursulas);
-  const strategy = CbdStrategy.create(cohort, conditionSet);
+  const strategy = CbdStrategy.create(cohort);
   expect(strategy.cohort).toEqual(cohort);
   return strategy;
 };
@@ -135,7 +135,6 @@ describe('CbdDeployedStrategy', () => {
       await deployedStrategy.decrypter.retrieveAndDecrypt(
         aliceProvider,
         conditionSet,
-        deployedStrategy.dkgRitual,
         variant,
         ciphertext,
         aad

--- a/test/unit/cbd-strategy.test.ts
+++ b/test/unit/cbd-strategy.test.ts
@@ -53,7 +53,7 @@ async function makeDeployedCbdStrategy() {
   const strategy = await makeCbdStrategy();
 
   const mockedDkg = fakeDkgFlow(variant, 0);
-  const mockedDkgRitual = fakeDkgRitual(mockedDkg);
+  const mockedDkgRitual = fakeDkgRitual(mockedDkg, mockedDkg.threshold);
   const web3Provider = fakeWeb3Provider(aliceSecretKey.toBEBytes());
   const getUrsulasSpy = mockGetUrsulas(ursulas);
   const initializeRitualSpy = mockInitializeRitual(mockedDkgRitual);

--- a/test/unit/cbd-strategy.test.ts
+++ b/test/unit/cbd-strategy.test.ts
@@ -104,10 +104,9 @@ describe('CbdDeployedStrategy', () => {
     const { mockedDkg, deployedStrategy } = await makeDeployedCbdStrategy();
 
     const message = 'this is a secret';
-    const { ciphertext, aad } = deployedStrategy.encrypter.encryptMessageCbd(
-      message,
-      conditionSet
-    );
+    const { ciphertext, aad } = deployedStrategy
+      .makeEncrypter(conditionSet)
+      .encryptMessageCbd(message);
 
     // Setup mocks for `retrieveAndDecrypt`
     const { decryptionShares } = fakeTDecFlow({

--- a/test/unit/pre-strategy.test.ts
+++ b/test/unit/pre-strategy.test.ts
@@ -42,12 +42,7 @@ const mockedUrsulas = fakeUrsulas().slice(0, 3);
 
 const makePreStrategy = async () => {
   const cohort = await makeCohort(mockedUrsulas);
-  const strategy = PreStrategy.create(
-    cohort,
-    conditionSet,
-    aliceSecretKey,
-    bobSecretKey
-  );
+  const strategy = PreStrategy.create(cohort, aliceSecretKey, bobSecretKey);
   expect(strategy.cohort).toEqual(cohort);
   return strategy;
 };
@@ -66,7 +61,6 @@ const makeDeployedPreStrategy = async () => {
   expect(makeTreasureMapSpy).toHaveBeenCalled();
   expect(encryptTreasureMapSpy).toHaveBeenCalled();
 
-  expect(deployedStrategy.conditionSet).toEqual(conditionSet);
   expect(deployedStrategy.cohort).toEqual(strategy.cohort);
 
   const ursulaAddresses = (

--- a/test/unit/pre-strategy.test.ts
+++ b/test/unit/pre-strategy.test.ts
@@ -118,8 +118,9 @@ describe('PreDeployedStrategy', () => {
       await makeDeployedPreStrategy();
 
     const plaintext = 'this is a secret';
-    const encryptedMessageKit =
-      deployedStrategy.encrypter.encryptMessagePre(plaintext);
+    const encryptedMessageKit = deployedStrategy
+      .makeEncrypter(conditionSet)
+      .encryptMessagePre(plaintext);
 
     // Setup mocks for `retrieveAndDecrypt`
     const getUrsulasSpy = mockGetUrsulas(mockedUrsulas);

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -500,11 +500,12 @@ export const mockRandomSessionStaticSecret = (secret: SessionStaticSecret) => {
 
 export const fakeRitualId = 0;
 
-export const fakeDkgRitual = (ritual: { dkg: Dkg }) => {
+export const fakeDkgRitual = (ritual: { dkg: Dkg }, thresold: number) => {
   return new DkgRitual(
     fakeRitualId,
     ritual.dkg.publicKey(),
-    ritual.dkg.publicParams()
+    ritual.dkg.publicParams(),
+    thresold
   );
 };
 


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:** 
- 2

**What this does:**
- Adds immutability to `*Strategy` fields
- Adds a new convenience method for creating an encrypted for a given `ConditionSet`

**Issues fixed/closed:**
- #125

**Why it's needed:**
- Avoiding mutating objects and coupling strategy with encrypter

**Notes for reviewers:**
- Please see the original issue first: #125 
- If we want to avoid the coupling between a strategy and a condition set completely, we should replace `strategy.encrypter` with a factory method (`makeEncrypter`) completely. I.e. remove `strategy.encrypter` field.
