### PR TITLE
Validate `functionAbi` using `ethers` ABI parser

### DIFF
--- a/src/conditions/base/contract.ts
+++ b/src/conditions/base/contract.ts
@@ -40,12 +40,16 @@ const functionAbiSchema = Joi.object({
   // Now we just need to validate against the parent schema
   // Validate method name
   const method = helper.state.ancestors[0].method;
-  const abiMethodName = Object.keys(asInterface.functions).find((name) =>
-    name.startsWith(`${method}(`)
-  );
-  const functionFragment = abiMethodName
-    ? asInterface.functions[abiMethodName]
-    : null;
+
+  let functionFragment;
+  try {
+    functionFragment = asInterface.getFunction(method);
+  } catch (e) {
+    return helper.message({
+      custom: `"functionAbi" contains ambiguous "${method}"`,
+    });
+  }
+
   if (!functionFragment) {
     return helper.message({
       custom: `"functionAbi" not valid for method: "${method}"`,

--- a/src/conditions/base/contract.ts
+++ b/src/conditions/base/contract.ts
@@ -46,7 +46,7 @@ const functionAbiSchema = Joi.object({
     functionFragment = asInterface.getFunction(method);
   } catch (e) {
     return helper.message({
-      custom: `"functionAbi" contains ambiguous "${method}"`,
+      custom: `"functionAbi" has no matching function for "${method}"`,
     });
   }
 

--- a/src/conditions/base/contract.ts
+++ b/src/conditions/base/contract.ts
@@ -25,13 +25,13 @@ const functionAbiSchema = Joi.object({
     });
   }
 
-  if (!asInterface.fragments) {
+  if (!asInterface.functions) {
     return helper.message({
       custom: '"functionAbi" is missing a function fragment',
     });
   }
 
-  if (asInterface.fragments.length > 1) {
+  if (Object.values(asInterface.functions).length !== 1) {
     return helper.message({
       custom: '"functionAbi" must contain exactly one function fragment',
     });
@@ -40,12 +40,15 @@ const functionAbiSchema = Joi.object({
   // Now we just need to validate against the parent schema
   // Validate method name
   const method = helper.state.ancestors[0].method;
-  const functionFragment = asInterface.fragments.filter(
-    (f) => f.name === method
-  )[0];
+  const abiMethodName = Object.keys(asInterface.functions).find((name) =>
+    name.startsWith(`${method}(`)
+  );
+  const functionFragment = abiMethodName
+    ? asInterface.functions[abiMethodName]
+    : null;
   if (!functionFragment) {
     return helper.message({
-      custom: '"functionAbi" does not contain the method specified as "method"',
+      custom: `"functionAbi" not valid for method: "${method}"`,
     });
   }
 

--- a/test/unit/conditions/base/contract.test.ts
+++ b/test/unit/conditions/base/contract.test.ts
@@ -123,7 +123,7 @@ describe('supports custom function abi', () => {
   const customParams: Record<string, CustomContextParam> = {};
   customParams[myCustomParam] = 1234;
 
-  it('accepts custom function abi', async () => {
+  it('accepts custom function abi with a custom parameter', async () => {
     const asJson = await conditionContext
       .withCustomParams(customParams)
       .toJson();
@@ -131,4 +131,109 @@ describe('supports custom function abi', () => {
     expect(asJson).toContain(USER_ADDRESS_PARAM);
     expect(asJson).toContain(myCustomParam);
   });
+
+  it.each([
+    {
+      method: 'balanceOf',
+      functionAbi: {
+        name: 'balanceOf',
+        type: 'function',
+        inputs: [{ name: '_owner', type: 'address' }],
+        outputs: [{ name: 'balance', type: 'uint256' }],
+        stateMutability: 'view',
+      },
+    },
+    {
+      method: 'get',
+      functionAbi: {
+        name: 'get',
+        type: 'function',
+        inputs: [],
+        outputs: [],
+        stateMutability: 'pure',
+      },
+    },
+  ])('accepts well-formed functionAbi', ({ method, functionAbi }) => {
+    expect(() =>
+      new ContractCondition({
+        ...contractConditionObj,
+        parameters: functionAbi.inputs.map(
+          (input) => `fake_parameter_${input}`
+        ), //
+        functionAbi,
+        method,
+      }).toObj()
+    ).not.toThrow();
+  });
+
+  it.each([
+    {
+      method: '1234',
+      expectedError: '"functionAbi.name" must be a string',
+      functionAbi: {
+        name: 1234, // invalid value
+        type: 'function',
+        inputs: [{ name: '_owner', type: 'address' }],
+        outputs: [{ name: 'balance', type: 'uint256' }],
+        stateMutability: 'view',
+      },
+    },
+    {
+      method: 'transfer',
+      expectedError: '"functionAbi.inputs" must be an array',
+      functionAbi: {
+        name: 'transfer',
+        type: 'function',
+        inputs: 'invalid value', // invalid value
+        outputs: [{ name: '_status', type: 'bool' }],
+        stateMutability: 'pure',
+      },
+    },
+    {
+      method: 'get',
+      expectedError:
+        '"functionAbi.stateMutability" must be one of [view, pure]',
+      functionAbi: {
+        name: 'get',
+        type: 'function',
+        inputs: [],
+        outputs: [],
+        stateMutability: 'invalid', // invalid value
+      },
+    },
+    {
+      method: 'test',
+      expectedError: '"functionAbi.outputs" must be an array',
+      functionAbi: {
+        name: 'test',
+        type: 'function',
+        inputs: [],
+        outputs: 'invalid value', // Invalid value
+        stateMutability: 'pure',
+      },
+    },
+    {
+      method: 'calculatePow',
+      expectedError:
+        'Invalid condition: "parameters" must have the same length as "functionAbi.inputs"',
+      functionAbi: {
+        name: 'calculatePow',
+        type: 'function',
+        // 'inputs': []   // Missing inputs array
+        outputs: [{ name: 'result', type: 'uint256' }],
+        stateMutability: 'view',
+      },
+    },
+  ])(
+    'rejects malformed functionAbi',
+    ({ method, expectedError, functionAbi }) => {
+      expect(() =>
+        new ContractCondition({
+          ...contractConditionObj,
+          functionAbi,
+          method,
+        }).toObj()
+      ).toThrow(expectedError);
+    }
+  );
 });

--- a/test/unit/conditions/base/contract.test.ts
+++ b/test/unit/conditions/base/contract.test.ts
@@ -7,7 +7,7 @@ import {
 import { ContractCondition } from '../../../../src/conditions/base';
 import { USER_ADDRESS_PARAM } from '../../../../src/conditions/const';
 import { fakeWeb3Provider } from '../../../utils';
-import { testContractConditionObj } from '../../testVariables';
+import { testContractConditionObj, testFunctionAbi } from '../../testVariables';
 
 describe('validation', () => {
   it('accepts on a valid schema', () => {
@@ -103,30 +103,10 @@ describe('accepts either standardContractType or functionAbi but not both or non
 });
 
 describe('supports custom function abi', () => {
-  const fakeFunctionAbi = {
-    name: 'myFunction',
-    type: 'function',
-    inputs: [
-      {
-        name: 'account',
-        type: 'address',
-      },
-      {
-        name: 'myCustomParam',
-        type: 'uint256',
-      },
-    ],
-    outputs: [
-      {
-        name: 'someValue',
-        type: 'uint256',
-      },
-    ],
-  };
   const contractConditionObj = {
     ...testContractConditionObj,
     standardContractType: undefined,
-    functionAbi: fakeFunctionAbi,
+    functionAbi: testFunctionAbi,
     method: 'myFunction',
     parameters: [USER_ADDRESS_PARAM, ':customParam'],
     returnValueTest: {

--- a/test/unit/testVariables.ts
+++ b/test/unit/testVariables.ts
@@ -48,6 +48,7 @@ export const testContractConditionObj = {
 export const testFunctionAbi = {
   name: 'myFunction',
   type: 'function',
+  stateMutability: 'view',
   inputs: [
     {
       internalType: 'address',
@@ -67,5 +68,4 @@ export const testFunctionAbi = {
       type: 'uint256',
     },
   ],
-  stateMutability: 'view',
 };


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:** 
-  1


**What this does:**
- Uses `ethers` to validate `functionABI`

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
- We've implemented somewhat basic validation for `functionABI`, but it's still possible to pass mangled/illegal JSON ABI into your conditions

**Notes for reviewers:**
- I need some input on this - It looks like there is going to be some overlap between `Joi` and `ethers`, and we have to implement some checks and balances ourselves on top of that. 
