### PR TITLE
Fix incorrect `Condition` parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.0.0-beta.3](https://github.com/nucypher/nucypher-ts/compare/v1.0.0-beta.2...v1.0.0-beta.3) (2023-07-07)
+
+
+### ⚠ BREAKING CHANGES
+
+* incorrect condition parsing leading to undefined variables in context
+
+### Bug Fixes
+
+* incorrect condition parsing leading to undefined variables in context ([298fe22](https://github.com/nucypher/nucypher-ts/commit/298fe22e25674682ac04240957129af815ae56c8))
+
 ## [1.0.0-beta.2](https://github.com/nucypher/nucypher-ts/compare/v1.0.0-alpha.0...v1.0.0-beta.2) (2023-07-07)
 
 ## [1.0.0-alpha.0](https://github.com/nucypher/nucypher-ts/compare/v1.0.0-beta.1...v1.0.0-alpha.0) (2023-06-27)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nucypher/nucypher-ts",
   "author": "Piotr Roslaniec <p.roslaniec@gmail.com>",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "license": "GPL-3.0-only",
   "repository": {
     "type": "git",

--- a/src/characters/porter.ts
+++ b/src/characters/porter.ts
@@ -9,7 +9,6 @@ import {
 import axios, { AxiosResponse } from 'axios';
 import qs from 'qs';
 
-import { ConditionContext } from '../conditions';
 import { Base64EncodedBytes, ChecksumAddress, HexEncodedBytes } from '../types';
 import { fromBase64, fromHexString, toBase64, toHexString } from '../utils';
 
@@ -138,18 +137,15 @@ export class Porter {
     aliceVerifyingKey: PublicKey,
     bobEncryptingKey: PublicKey,
     bobVerifyingKey: PublicKey,
-    conditionsContext?: ConditionContext
+    conditionContextJSON?: string | undefined
   ): Promise<readonly RetrieveCFragsResult[]> {
-    const context = conditionsContext
-      ? await conditionsContext.toJson()
-      : undefined;
     const data: PostRetrieveCFragsRequest = {
       treasure_map: toBase64(treasureMap.toBytes()),
       retrieval_kits: retrievalKits.map((rk) => toBase64(rk.toBytes())),
       alice_verifying_key: toHexString(aliceVerifyingKey.toCompressedBytes()),
       bob_encrypting_key: toHexString(bobEncryptingKey.toCompressedBytes()),
       bob_verifying_key: toHexString(bobVerifyingKey.toCompressedBytes()),
-      context,
+      context: conditionContextJSON,
     };
     const resp: AxiosResponse<PostRetrieveCFragsResponse> = await axios.post(
       new URL('/retrieve_cfrags', this.porterUrl).toString(),

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -82,7 +82,7 @@ export const fakeAlice = (aliceKey = 'fake-secret-key-32-bytes-alice-x') => {
 };
 
 export const fakeWeb3Provider = (
-  secretKeyBytes: Uint8Array,
+  secretKeyBytes = SecretKey.random().toBEBytes(),
   blockNumber?: number,
   blockTimestamp?: number
 ): ethers.providers.Web3Provider => {


### PR DESCRIPTION
**Type of PR:**
- Bugfix

**Required reviews:** 
- 2

**What this does:**
- Fixes a bug where conditions would be incorrectly deserialized from their string format, leading to `ConditionContext` attempting to access `undefined` fields 
- Changes how `ConditionContext` is prepared for Porter to fix this issue passing silently in tests

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
- Need to back-port this to `alpha` tree
