### PR TITLE
Replace `variant` parameter with a default `FerveoVariant.Simple`

### DIFF
--- a/src/dkg.ts
+++ b/src/dkg.ts
@@ -1,43 +1,9 @@
-import {
-  combineDecryptionSharesPrecomputed,
-  combineDecryptionSharesSimple,
-  DecryptionSharePrecomputed,
-  DecryptionShareSimple,
-  DkgPublicKey,
-  FerveoVariant,
-  SharedSecret,
-} from '@nucypher/nucypher-core';
+import { DkgPublicKey } from '@nucypher/nucypher-core';
 import { ethers } from 'ethers';
 
 import { DkgCoordinatorAgent, DkgRitualState } from './agents/coordinator';
 import { ChecksumAddress } from './types';
 import { fromHexString, objectEquals } from './utils';
-
-export function getVariantClass(
-  variant: FerveoVariant
-): typeof DecryptionShareSimple | typeof DecryptionSharePrecomputed {
-  if (variant.equals(FerveoVariant.simple)) {
-    return DecryptionShareSimple;
-  } else if (variant.equals(FerveoVariant.precomputed)) {
-    return DecryptionSharePrecomputed;
-  } else {
-    throw new Error(`Invalid FerveoVariant: ${variant}`);
-  }
-}
-
-export function getCombineDecryptionSharesFunction(
-  variant: FerveoVariant
-): (
-  shares: DecryptionShareSimple[] | DecryptionSharePrecomputed[]
-) => SharedSecret {
-  if (variant.equals(FerveoVariant.simple)) {
-    return combineDecryptionSharesSimple;
-  } else if (variant.equals(FerveoVariant.precomputed)) {
-    return combineDecryptionSharesPrecomputed;
-  } else {
-    throw new Error(`Invalid FerveoVariant: ${variant}`);
-  }
-}
 
 export type DkgRitualParameters = {
   sharesNum: number;

--- a/test/unit/cbd-strategy.test.ts
+++ b/test/unit/cbd-strategy.test.ts
@@ -113,7 +113,6 @@ describe('CbdDeployedStrategy', () => {
     // Setup mocks for `retrieveAndDecrypt`
     const { decryptionShares } = fakeTDecFlow({
       ...mockedDkg,
-      variant,
       message: toBytes(message),
       aad,
       ciphertext,
@@ -138,7 +137,6 @@ describe('CbdDeployedStrategy', () => {
       await deployedStrategy.decrypter.retrieveAndDecrypt(
         aliceProvider,
         conditionExpr,
-        variant,
         ciphertext
       );
     expect(getUrsulasSpy).toHaveBeenCalled();


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:** 
- 1

**What this does:**
- Hides `FerveoVariant` from user-facing API
- Sets `FerveoVariant.Simple` as the default variant

**Issues fixed/closed:**
- Fixes https://github.com/nucypher/nucypher-ts/issues/248
