### PR TITLE
Update CBD elements to TACo including Porter endpoint

### DIFF
--- a/packages/shared/src/porter.ts
+++ b/packages/shared/src/porter.ts
@@ -86,7 +86,7 @@ export type RetrieveCFragsResult = {
   readonly errors: Record<ChecksumAddress, string>;
 };
 
-// /taco_decrypt
+// /decrypt
 
 type PostTacoDecryptRequest = {
   readonly threshold: number;
@@ -193,7 +193,7 @@ export class PorterClient {
       threshold,
     };
     const resp: AxiosResponse<PostTacoDecryptResponse> = await axios.post(
-      new URL('/taco_decrypt', this.porterUrl).toString(),
+      new URL('/decrypt', this.porterUrl).toString(),
       data,
     );
 

--- a/packages/shared/src/porter.ts
+++ b/packages/shared/src/porter.ts
@@ -86,9 +86,9 @@ export type RetrieveCFragsResult = {
   readonly errors: Record<ChecksumAddress, string>;
 };
 
-// /cbd_decrypt
+// /taco_decrypt
 
-type PostCbdDecryptRequest = {
+type PostTacoDecryptRequest = {
   readonly threshold: number;
   readonly encrypted_decryption_requests: Record<
     ChecksumAddress,
@@ -96,7 +96,7 @@ type PostCbdDecryptRequest = {
   >;
 };
 
-type PostCbdDecryptResponse = {
+type PostTacoDecryptResponse = {
   result: {
     decryption_results: {
       encrypted_decryption_responses: Record<
@@ -108,7 +108,7 @@ type PostCbdDecryptResponse = {
   };
 };
 
-export type CbdDecryptResult = {
+export type TacoDecryptResult = {
   encryptedResponses: Record<string, EncryptedThresholdDecryptionResponse>;
   errors: Record<string, string>;
 };
@@ -179,11 +179,11 @@ export class PorterClient {
     });
   }
 
-  public async cbdDecrypt(
+  public async tacoDecrypt(
     encryptedRequests: Record<string, EncryptedThresholdDecryptionRequest>,
     threshold: number,
-  ): Promise<CbdDecryptResult> {
-    const data: PostCbdDecryptRequest = {
+  ): Promise<TacoDecryptResult> {
+    const data: PostTacoDecryptRequest = {
       encrypted_decryption_requests: Object.fromEntries(
         Object.entries(encryptedRequests).map(([ursula, encryptedRequest]) => [
           ursula,
@@ -192,8 +192,8 @@ export class PorterClient {
       ),
       threshold,
     };
-    const resp: AxiosResponse<PostCbdDecryptResponse> = await axios.post(
-      new URL('/cbd_decrypt', this.porterUrl).toString(),
+    const resp: AxiosResponse<PostTacoDecryptResponse> = await axios.post(
+      new URL('/taco_decrypt', this.porterUrl).toString(),
       data,
     );
 

--- a/packages/taco/src/conditions/context/providers.ts
+++ b/packages/taco/src/conditions/context/providers.ts
@@ -77,7 +77,7 @@ export class WalletAuthenticationProvider {
         ],
       },
       domain: {
-        name: 'cbd',
+        name: 'taco',
         version: '1',
         chainId,
         salt,

--- a/packages/taco/src/tdec.ts
+++ b/packages/taco/src/tdec.ts
@@ -93,13 +93,13 @@ const retrieve = async (
   );
 
   const porter = new PorterClient(porterUri);
-  const { encryptedResponses, errors } = await porter.cbdDecrypt(
+  const { encryptedResponses, errors } = await porter.tacoDecrypt(
     encryptedRequests,
     threshold,
   );
   if (Object.keys(encryptedResponses).length < threshold) {
     throw new Error(
-      `Threshold of responses not met; CBD decryption failed with errors: ${JSON.stringify(
+      `Threshold of responses not met; TACo decryption failed with errors: ${JSON.stringify(
         errors,
       )}`,
     );

--- a/packages/taco/test/taco.test.ts
+++ b/packages/taco/test/taco.test.ts
@@ -10,8 +10,8 @@ import {
   fakeProvider,
   fakeSigner,
   fakeTDecFlow,
-  mockCbdDecrypt,
   mockGetRitualIdFromPublicKey,
+  mockTacoDecrypt,
 } from '@nucypher/test-utils';
 import { beforeAll, describe, expect, it } from 'vitest';
 
@@ -65,7 +65,7 @@ describe('taco', () => {
       mockedDkg.ritualId,
     );
     const requesterSessionKey = SessionStaticSecret.random();
-    const decryptSpy = mockCbdDecrypt(
+    const decryptSpy = mockTacoDecrypt(
       mockedDkg.ritualId,
       decryptionShares,
       participantSecrets,

--- a/packages/test-utils/src/utils.ts
+++ b/packages/test-utils/src/utils.ts
@@ -29,12 +29,12 @@ import {
   VerifiedKeyFrag,
 } from '@nucypher/nucypher-core';
 import {
-  CbdDecryptResult,
   ChecksumAddress,
   DkgCoordinatorAgent,
   GetUrsulasResult,
   PorterClient,
   RetrieveCFragsResult,
+  TacoDecryptResult,
   toHexString,
   Ursula,
   zip,
@@ -281,7 +281,7 @@ export const fakeTDecFlow = ({
   };
 };
 
-export const mockCbdDecrypt = (
+export const mockTacoDecrypt = (
   ritualId: number,
   decryptionShares: (DecryptionSharePrecomputed | DecryptionShareSimple)[],
   participantSecrets: Record<string, SessionStaticSecret>,
@@ -302,12 +302,12 @@ export const mockCbdDecrypt = (
     ),
   );
 
-  const result: CbdDecryptResult = {
+  const result: TacoDecryptResult = {
     encryptedResponses,
     errors,
   };
   return vi
-    .spyOn(PorterClient.prototype, 'cbdDecrypt')
+    .spyOn(PorterClient.prototype, 'tacoDecrypt')
     .mockImplementation(() => {
       return Promise.resolve(result);
     });


### PR DESCRIPTION
**DO NOT MERGE** until associated Porter PR (https://github.com/nucypher/nucypher-porter/pull/43) is merged and running on `lynx`/`tapir` testnets.


**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [X] Other

**Required reviews:** 
> How many reviews does the PR author need?
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
- Update use of Porter's `/cbd_decrypt` endpoint to ~~`/taco_decrypt`~~ `/decrypt`.
- Update all other CBD elements to use TACo.

**Issues fixed/closed:**
Related to https://github.com/nucypher/nucypher-porter/pull/43

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
