### PR TITLE
Fix custom parameters not being parsed in complex conditions

### DIFF
--- a/packages/taco/src/conditions/condition-expr.ts
+++ b/packages/taco/src/conditions/condition-expr.ts
@@ -6,6 +6,13 @@ import { SemVer } from 'semver';
 import { Condition } from './condition';
 import { ConditionContext, CustomContextParam } from './context';
 
+const ERR_VERSION = (provided: string, current: string) =>
+  `Version provided, ${provided}, is incompatible with current version, ${current}`;
+const ERR_CONDITION = (condition: Record<string, unknown>) =>
+  `Invalid condition: unrecognized condition data ${JSON.stringify(
+    condition,
+  )}`;
+
 export type ConditionExpressionJSON = {
   version: string;
   condition: Record<string, unknown>;
@@ -31,17 +38,11 @@ export class ConditionExpression {
     const receivedVersion = new SemVer(obj.version);
     const currentVersion = new SemVer(ConditionExpression.version);
     if (receivedVersion.major > currentVersion.major) {
-      throw new Error(
-        `Version provided, ${obj.version}, is incompatible with current version, ${ConditionExpression.version}`,
-      );
+      throw new Error(ERR_VERSION(obj.version, ConditionExpression.version));
     }
 
     if (!obj.condition) {
-      throw new Error(
-        `Invalid condition: unrecognized condition data ${JSON.stringify(
-          obj.condition,
-        )}`,
-      );
+      throw new Error(ERR_CONDITION(obj.condition));
     }
 
     const condition = Condition.fromObj(obj.condition);
@@ -71,7 +72,7 @@ export class ConditionExpression {
   ): ConditionContext {
     return new ConditionContext(
       provider,
-      [this.condition],
+      this.condition,
       customParameters,
       signer,
     );

--- a/packages/taco/src/conditions/condition.ts
+++ b/packages/taco/src/conditions/condition.ts
@@ -22,6 +22,11 @@ import { USER_ADDRESS_PARAM } from './const';
 type ConditionSchema = z.ZodSchema;
 export type ConditionProps = z.infer<ConditionSchema>;
 
+const ERR_INVALID_CONDITION = (error: z.ZodError) =>
+  `Invalid condition: ${JSON.stringify(error.issues)}`;
+const ERR_INVALID_CONDITION_TYPE = (type: string) =>
+  `Invalid condition type: ${type}`;
+
 class ConditionFactory {
   public static conditionFromProps(obj: ConditionProps): Condition {
     switch (obj.conditionType) {
@@ -34,7 +39,7 @@ class ConditionFactory {
       case CompoundConditionType:
         return new CompoundCondition(obj as CompoundConditionProps);
       default:
-        throw new Error(`Invalid conditionType: ${obj.conditionType}`);
+        throw new Error(ERR_INVALID_CONDITION_TYPE(obj.conditionType));
     }
   }
 }
@@ -46,7 +51,7 @@ export class Condition {
   ) {
     const { data, error } = Condition.validate(schema, value);
     if (error) {
-      throw new Error(`Invalid condition: ${JSON.stringify(error.issues)}`);
+      throw new Error(ERR_INVALID_CONDITION(error));
     }
     this.value = data;
   }
@@ -72,7 +77,7 @@ export class Condition {
   public toObj() {
     const { data, error } = Condition.validate(this.schema, this.value);
     if (error) {
-      throw new Error(`Invalid condition: ${JSON.stringify(error.issues)}`);
+      throw new Error(ERR_INVALID_CONDITION(error));
     }
     return data;
   }

--- a/packages/taco/test/conditions/condition-expr.test.ts
+++ b/packages/taco/test/conditions/condition-expr.test.ts
@@ -240,7 +240,7 @@ describe('condition set', () => {
             version: ConditionExpression.version,
             condition: conditionObj,
           });
-        }).toThrow(`Invalid conditionType: ${invalidConditionType}`);
+        }).toThrow(`Invalid condition type: ${invalidConditionType}`);
       },
     );
 

--- a/packages/taco/test/conditions/conditions.test.ts
+++ b/packages/taco/test/conditions/conditions.test.ts
@@ -39,7 +39,7 @@ describe('conditions', () => {
 
     const context = new ConditionContext(
       fakeProvider(),
-      [condition],
+      condition,
       {':time': 100},
       fakeSigner()
     );

--- a/packages/taco/test/conditions/conditions.test.ts
+++ b/packages/taco/test/conditions/conditions.test.ts
@@ -4,12 +4,12 @@ import {beforeAll, describe, expect, it} from "vitest";
 import { initialize } from "../../src";
 import { CompoundCondition, ConditionContext } from "../../src/conditions";
 
-describe('compound condition', () => {
+describe('conditions', () => {
   beforeAll(async () => {
     await initialize();
   });
 
-  it('can be created', () => {
+  it('creates a complex condition with custom parameters', async () => {
     const hasPositiveBalance = {
       chain: 80001,
       method: 'eth_getBalance',
@@ -45,7 +45,8 @@ describe('compound condition', () => {
     );
     expect(context).toBeDefined();
 
-    const asObj = condition.toObj();
+    const asObj = await context.toObj();
     expect(asObj).toBeDefined();
+    expect(asObj[':time']).toBe(100);
   });
 });

--- a/packages/taco/test/conditions/context.test.ts
+++ b/packages/taco/test/conditions/context.test.ts
@@ -63,11 +63,11 @@ describe('context', () => {
     };
     const contractCondition = new ContractCondition(contractConditionObj);
     const conditionExpr = new ConditionExpression(contractCondition);
-    const conditionContext = conditionExpr.buildContext(provider, {}, signer);
+    const context = conditionExpr.buildContext(provider, {}, signer);
 
     describe('return value test', () => {
       it('accepts on a custom context parameters', async () => {
-        const asObj = await conditionContext
+        const asObj = await context
           .withCustomParams(customParams)
           .toObj();
         expect(asObj).toBeDefined();
@@ -75,7 +75,7 @@ describe('context', () => {
       });
 
       it('rejects on a missing custom context parameter', async () => {
-        await expect(conditionContext.toObj()).rejects.toThrow(
+        await expect(context.toObj()).rejects.toThrow(
           `Missing custom context parameter(s): ${customParamKey}`,
         );
       });
@@ -86,11 +86,21 @@ describe('context', () => {
       RESERVED_CONTEXT_PARAMS.forEach((reservedParam) => {
         badCustomParams[reservedParam] = 'this-will-throw';
         expect(() =>
-          conditionContext.withCustomParams(badCustomParams),
+          context.withCustomParams(badCustomParams),
         ).toThrow(
           `Cannot use reserved parameter name ${reservedParam} as custom parameter`,
         );
       });
+    });
+
+    it('rejects on using a custom parameter that was not requested', async () => {
+      const badCustomParamKey = ':notRequested';
+      const badCustomParams: Record<string, CustomContextParam> = {};
+      badCustomParams[':customParam'] = 'this-is-fine';
+      badCustomParams[badCustomParamKey] = 'this-will-throw';
+      await expect(context.withCustomParams(badCustomParams).toObj()).rejects.toThrow(
+        `Unknown custom context parameter(s): ${badCustomParamKey}`,
+      );
     });
 
     it('detects if a signer is required', () => {


### PR DESCRIPTION
**Type of PR:**
- Bugfix

**Required reviews:**
- 2

**What this does:**
- Adds a recursive search for custom context parameters in `CompoundCondition`
- Adds validation for unknown custom context parameters
- Refactors have conditions are passed to context (internal change)

**Notes for reviewers:**
- Based on https://github.com/nucypher/nucypher-ts/pull/331
