### PR TITLE
Fix contract registry not parsing contract artifacts correctly

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -35,6 +35,7 @@
     "lint": "eslint --ext .ts src",
     "lint:fix": "pnpm lint --fix",
     "package-check": "package-check",
+    "test": "vitest run",
     "typechain": "ts-node scripts/typechain.ts",
     "typedoc": "typedoc"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nucypher/shared",
-  "version": "0.1.0-rc.2",
+  "version": "0.1.0-rc.3",
   "keywords": [
     "pre",
     "taco",

--- a/packages/shared/src/contracts/registry.ts
+++ b/packages/shared/src/contracts/registry.ts
@@ -1,6 +1,6 @@
-import * as lynxRegistryJson from '@nucypher/nucypher-contracts/deployment/artifacts/lynx.json';
-import * as mainnetRegistryJson from '@nucypher/nucypher-contracts/deployment/artifacts/mainnet.json';
-import * as tapirRegistryJson from '@nucypher/nucypher-contracts/deployment/artifacts/tapir.json';
+import lynxRegistryJson from '@nucypher/nucypher-contracts/deployment/artifacts/lynx.json';
+import mainnetRegistryJson from '@nucypher/nucypher-contracts/deployment/artifacts/mainnet.json';
+import tapirRegistryJson from '@nucypher/nucypher-contracts/deployment/artifacts/tapir.json';
 
 import { Domain } from '../porter';
 import { ChecksumAddress } from '../types';

--- a/packages/shared/test/registry.spec.ts
+++ b/packages/shared/test/registry.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { ChainId, ContractName, getContract } from '../src';
+
+const testCases: [string, number, ContractName][] = [
+  ['lynx', ChainId.MUMBAI, 'Coordinator'],
+  ['lynx', ChainId.MUMBAI, 'GlobalAllowList'],
+  ['tapir', ChainId.MUMBAI, 'Coordinator'],
+  ['tapir', ChainId.MUMBAI, 'GlobalAllowList'],
+];
+
+describe('registry', () => {
+  for (const testCase of testCases) {
+    const [domain, chainId, contract] = testCase;
+    it(`should for domain ${domain}, chainId ${chainId}, contract ${contract}`, () => {
+      const contractAddress = getContract(domain, chainId, contract);
+      expect(contractAddress).toBeDefined();
+    });
+  }
+});

--- a/packages/shared/test/registry.spec.ts
+++ b/packages/shared/test/registry.spec.ts
@@ -5,8 +5,10 @@ import { ChainId, ContractName, getContract } from '../src';
 const testCases: [string, number, ContractName][] = [
   ['lynx', ChainId.MUMBAI, 'Coordinator'],
   ['lynx', ChainId.MUMBAI, 'GlobalAllowList'],
+  ['lynx', ChainId.MUMBAI, 'SubscriptionManager'],
   ['tapir', ChainId.MUMBAI, 'Coordinator'],
   ['tapir', ChainId.MUMBAI, 'GlobalAllowList'],
+  ['tapir', ChainId.MUMBAI, 'SubscriptionManager'],
 ];
 
 describe('registry', () => {

--- a/packages/taco/package.json
+++ b/packages/taco/package.json
@@ -49,8 +49,8 @@
     "@types/semver": "^7.5.0"
   },
   "peerDependencies": {
-    "ethers": "^5.7.2",
-    "@nucypher/shared": "workspace:*"
+    "@nucypher/shared": "workspace:*",
+    "ethers": "^5.7.2"
   },
   "engines": {
     "node": ">=18",

--- a/packages/taco/package.json
+++ b/packages/taco/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nucypher/taco",
-  "version": "0.1.0-rc.4",
+  "version": "0.1.0-rc.5",
   "keywords": [
     "taco",
     "threshold",
@@ -40,7 +40,7 @@
   "dependencies": {
     "@ethersproject/abstract-signer": "^5.7.0",
     "@nucypher/nucypher-core": "0.13.0-alpha.1",
-    "@nucypher/shared": "0.1.0-rc.2",
+    "@nucypher/shared": "0.1.0-rc.3",
     "semver": "^7.5.2",
     "zod": "^3.22.4"
   },
@@ -49,7 +49,8 @@
     "@types/semver": "^7.5.0"
   },
   "peerDependencies": {
-    "ethers": "^5.7.2"
+    "ethers": "^5.7.2",
+    "@nucypher/shared": "workspace:*"
   },
   "engines": {
     "node": ">=18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -531,7 +531,7 @@ importers:
         specifier: 0.13.0-alpha.1
         version: 0.13.0-alpha.1
       '@nucypher/shared':
-        specifier: 0.1.0-rc.2
+        specifier: 0.1.0-rc.3
         version: link:../shared
       ethers:
         specifier: ^5.7.2


### PR DESCRIPTION
**Type of PR:**
- Bugfix

**Required reviews:**
- 1

**What this does:**
- Fixes not using the default import in contract registry import (from `nucypher-contracts` package)
- Fixes linter
- Releases new RC version

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
- You can see the actual fix [here](https://github.com/nucypher/nucypher-ts/pull/353/files#r1367686471). The remainder of this PR are chores that have to do fix fixing the lining and releasing the fixed RC version.