### PR TITLE
Update Gitbook docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ contracts/compiled
 examples/*/pnpm-lock.yaml
 pnpm-debug.log
 docs-json
-./docs
 .next
+packages/docs
+docs

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "postinstall": "pnpm build",
     "typedoc": "typedoc",
-    "typedoc:all": "pnpm run --parallel --aggregate-output --reporter append-only typedoc",
-    "typedoc:publish": "gh-pages -m \"[ci skip] Update typedoc docs\" -d docs",
+    "typedoc:publish": "gh-pages -m \"[ci skip] Update typedoc docs\" -d docs --dotfiles",
     "format": "prettier --check \"./**/*.ts\" README.md",
     "format:fix": "prettier --write \"./**/*.ts\" README.md",
     "lint": "pnpm run --parallel --aggregate-output --reporter append-only lint",

--- a/packages/taco/.eslintrc.js
+++ b/packages/taco/.eslintrc.js
@@ -1,5 +1,5 @@
-const baseConfig = require('../../.eslintrc.js')
+const baseConfig = require('../../.eslintrc.js');
 
 module.exports = {
   ...baseConfig,
-}
+};

--- a/packages/taco/README.md
+++ b/packages/taco/README.md
@@ -1,3 +1,60 @@
 # `@nucypher/taco`
 
-## [`nucypher/nucypher-ts`](../../README.md)
+### [`nucypher/nucypher-ts`](../../README.md)
+
+## Usage
+
+First, install the package:
+
+```bash
+$ yarn add @nucypher/taco ethers@5.7.2
+```
+
+### Encrypt your data
+
+```typescript
+import {initialize, encrypt, conditions, domains} from '@nucypher/taco';
+import {ethers} from "ethers";
+
+// We have to initialize the TACo library first
+await initialize();
+
+const web3Provider = new ethers.providers.Web3Provider(window.ethereum);
+
+const ownsNFT = new conditions.predefined.ERC721Ownership({
+  contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
+  parameters: [3591],
+  chain: 5,
+});
+
+const message = "my secret message";
+
+const messageKit = await encrypt(
+  web3Provider,
+  domains.TESTNET,
+  message,
+  ownsNFT,
+  ritualId,
+  web3Provider.getSigner()
+);
+```
+
+### Decrypt your data
+
+```typescript
+import {initialize, decrypt, domains, getPorterUri} from '@nucypher/taco';
+import {ethers} from "ethers";
+
+// We have to initialize the TACo library first
+await initialize();
+
+const web3Provider = new ethers.providers.Web3Provider(window.ethereum);
+
+const decryptedMessage = await decrypt(
+  web3Provider,
+  domains.TESTNET,
+  messageKit,
+  getPorterUri(domains.TESTNET),
+  web3Provider.getSigner()
+);
+```

--- a/packages/taco/README.md
+++ b/packages/taco/README.md
@@ -13,8 +13,8 @@ $ yarn add @nucypher/taco ethers@5.7.2
 ### Encrypt your data
 
 ```typescript
-import {initialize, encrypt, conditions, domains} from '@nucypher/taco';
-import {ethers} from "ethers";
+import { conditions, domains, encrypt, initialize } from '@nucypher/taco';
+import { ethers } from 'ethers';
 
 // We have to initialize the TACo library first
 await initialize();
@@ -27,7 +27,7 @@ const ownsNFT = new conditions.predefined.ERC721Ownership({
   chain: 5,
 });
 
-const message = "my secret message";
+const message = 'my secret message';
 
 const messageKit = await encrypt(
   web3Provider,
@@ -35,15 +35,15 @@ const messageKit = await encrypt(
   message,
   ownsNFT,
   ritualId,
-  web3Provider.getSigner()
+  web3Provider.getSigner(),
 );
 ```
 
 ### Decrypt your data
 
 ```typescript
-import {initialize, decrypt, domains, getPorterUri} from '@nucypher/taco';
-import {ethers} from "ethers";
+import { decrypt, domains, getPorterUri, initialize } from '@nucypher/taco';
+import { ethers } from 'ethers';
 
 // We have to initialize the TACo library first
 await initialize();
@@ -55,6 +55,6 @@ const decryptedMessage = await decrypt(
   domains.TESTNET,
   messageKit,
   getPorterUri(domains.TESTNET),
-  web3Provider.getSigner()
+  web3Provider.getSigner(),
 );
 ```

--- a/packages/taco/examples/README.md
+++ b/packages/taco/examples/README.md
@@ -1,0 +1,5 @@
+# `examples/taco`
+
+These examples are not tested, but are typechecked with `pnpm type-check` instead.
+
+Some of these examples are used in the documentation. Others, are provided as an API reference.

--- a/packages/taco/examples/README.md
+++ b/packages/taco/examples/README.md
@@ -1,5 +1,7 @@
 # `examples/taco`
 
-These examples are not tested, but are typechecked with `pnpm type-check` instead.
+These examples are not tested, but are typechecked with `pnpm type-check`
+instead.
 
-Some of these examples are used in the documentation. Others, are provided as an API reference.
+Some of these examples are used in the documentation. Others, are provided as an
+API reference.

--- a/packages/taco/examples/conditions.ts
+++ b/packages/taco/examples/conditions.ts
@@ -1,0 +1,57 @@
+import { conditions } from '../src';
+import { ContractConditionType } from '../src/conditions';
+import { USER_ADDRESS_PARAM } from '../src/conditions/const';
+
+const ownsNFT = new conditions.predefined.ERC721Ownership({
+  contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
+  parameters: [3591],
+  chain: 5,
+});
+console.assert(ownsNFT.requiresSigner(), 'ERC721Ownership requires signer');
+
+const hasAtLeastTwoNFTs = new conditions.predefined.ERC721Balance({
+  contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
+  chain: 5,
+  returnValueTest: {
+    index: 0,
+    comparator: '>=',
+    value: 2,
+  },
+});
+console.assert(
+  hasAtLeastTwoNFTs.requiresSigner(),
+  'ERC721Balance requires signer',
+);
+
+const ownsNFTRaw = new conditions.base.ContractCondition({
+  // Provided by the `predefined.ERC721Balance`
+  conditionType: ContractConditionType,
+  method: 'balanceOf',
+  parameters: [USER_ADDRESS_PARAM], // ':userAddress'
+  standardContractType: 'ERC721',
+  // User-provided
+  contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
+  chain: 5,
+  returnValueTest: {
+    index: 0,
+    comparator: '>',
+    value: 0,
+  },
+});
+console.assert(ownsNFTRaw.requiresSigner(), 'ContractCondition requires signer');
+
+const hasAnyNativeAsset = new conditions.base.RpcCondition({
+  conditionType: 'rpc',
+  chain: 5,
+  method: 'eth_getBalance',
+  parameters: [':userAddress'],
+  returnValueTest: {
+    index: 0,
+    comparator: '>',
+    value: 0,
+  },
+});
+console.assert(
+  hasAnyNativeAsset.requiresSigner(),
+  'RpcCondition requires signer',
+);

--- a/packages/taco/examples/conditions.ts
+++ b/packages/taco/examples/conditions.ts
@@ -38,7 +38,10 @@ const ownsNFTRaw = new conditions.base.ContractCondition({
     value: 0,
   },
 });
-console.assert(ownsNFTRaw.requiresSigner(), 'ContractCondition requires signer');
+console.assert(
+  ownsNFTRaw.requiresSigner(),
+  'ContractCondition requires signer',
+);
 
 const hasAnyNativeAsset = new conditions.base.RpcCondition({
   conditionType: 'rpc',

--- a/packages/taco/examples/conditions.ts
+++ b/packages/taco/examples/conditions.ts
@@ -1,6 +1,5 @@
 import { conditions } from '../src';
 import { ContractConditionType } from '../src/conditions';
-import { USER_ADDRESS_PARAM } from '../src/conditions/const';
 
 const ownsNFT = new conditions.predefined.ERC721Ownership({
   contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
@@ -27,7 +26,7 @@ const ownsNFTRaw = new conditions.base.ContractCondition({
   // Provided by the `predefined.ERC721Balance`
   conditionType: ContractConditionType,
   method: 'balanceOf',
-  parameters: [USER_ADDRESS_PARAM], // ':userAddress'
+  parameters: [':userAddress'],
   standardContractType: 'ERC721',
   // User-provided
   contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
@@ -40,7 +39,7 @@ const ownsNFTRaw = new conditions.base.ContractCondition({
 });
 console.assert(
   ownsNFTRaw.requiresSigner(),
-  'ContractCondition requires signer',
+  'ContractCondition requires a signer',
 );
 
 const hasAnyNativeAsset = new conditions.base.RpcCondition({
@@ -57,4 +56,33 @@ const hasAnyNativeAsset = new conditions.base.RpcCondition({
 console.assert(
   hasAnyNativeAsset.requiresSigner(),
   'RpcCondition requires signer',
+);
+
+const ownsNFTOnChain5 = new conditions.predefined.ERC721Ownership({
+  contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
+  parameters: [3591],
+  chain: 5, // The first network we target
+});
+
+const hasAnyNativeAssetOnChain1 = new conditions.base.RpcCondition({
+  conditionType: 'rpc',
+  chain: 1, // The second network we target
+  method: 'eth_getBalance',
+  parameters: [':userAddress'],
+  returnValueTest: {
+    index: 0,
+    comparator: '>',
+    value: 0,
+  },
+});
+
+const multichainCondition = new conditions.base.CompoundCondition({
+  conditionType: 'compound',
+  operator: 'and',
+  operands: [ownsNFTOnChain5, hasAnyNativeAssetOnChain1],
+});
+
+console.assert(
+  multichainCondition.requiresSigner(),
+  'CompoundCondition requires signer',
 );

--- a/packages/taco/examples/encrypt-decrypt.ts
+++ b/packages/taco/examples/encrypt-decrypt.ts
@@ -1,0 +1,66 @@
+import { ethers } from 'ethers';
+
+import {
+  conditions,
+  decrypt,
+  domains,
+  encrypt,
+  getPorterUri,
+  initialize,
+  ThresholdMessageKit,
+  toBytes,
+} from '../src';
+
+const ritualId = 1;
+
+const run = async () => {
+  // The data encryptor runs this part
+  const doEncrypt = async (message: string) => {
+    // We have to initialize TACo library first
+    await initialize();
+
+    // @ts-ignore
+    const web3Provider = new ethers.providers.Web3Provider(window.ethereum);
+    const ownsNFT = new conditions.predefined.ERC721Ownership({
+      contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
+      parameters: [3591],
+      chain: 5,
+    });
+    const messageKit = await encrypt(
+      web3Provider,
+      domains.TESTNET,
+      message,
+      ownsNFT,
+      ritualId,
+      web3Provider.getSigner(),
+    );
+    return messageKit;
+  };
+
+  // The data recipient runs this part
+  const doDecrypt = async (messageKit: ThresholdMessageKit) => {
+    // We have to initialize TACo library first
+    await initialize();
+
+    // @ts-ignore
+    const web3Provider = new ethers.providers.Web3Provider(window.ethereum);
+    const decryptedMessage = await decrypt(
+      web3Provider,
+      domains.TESTNET,
+      messageKit,
+      getPorterUri(domains.TESTNET),
+      web3Provider.getSigner(),
+    );
+    return decryptedMessage;
+  };
+
+  const message = 'my secret message';
+  const encryptedMessage = await doEncrypt(message);
+  const decryptedMessage = await doDecrypt(encryptedMessage);
+
+  if (decryptedMessage === toBytes(message)) {
+    console.log('Success!');
+  }
+};
+
+run();

--- a/packages/taco/package.json
+++ b/packages/taco/package.json
@@ -35,6 +35,7 @@
     "lint:fix": "pnpm lint --fix",
     "package-check": "package-check",
     "test": "vitest run",
+    "type-check": "tsc --noEmit",
     "typedoc": "typedoc"
   },
   "dependencies": {

--- a/packages/taco/src/conditions/predefined/erc721.ts
+++ b/packages/taco/src/conditions/predefined/erc721.ts
@@ -27,7 +27,7 @@ export class ERC721Ownership extends ContractCondition {
   }
 }
 
-type ERC721BalanceFields = 'contractAddress' | 'chain';
+type ERC721BalanceFields = 'contractAddress' | 'chain' | 'returnValueTest';
 
 const ERC721BalanceDefaults: Omit<ContractConditionProps, ERC721BalanceFields> =
   {
@@ -35,11 +35,6 @@ const ERC721BalanceDefaults: Omit<ContractConditionProps, ERC721BalanceFields> =
     method: 'balanceOf',
     parameters: [USER_ADDRESS_PARAM],
     standardContractType: 'ERC721',
-    returnValueTest: {
-      index: 0,
-      comparator: '>',
-      value: '0',
-    },
   };
 
 export class ERC721Balance extends ContractCondition {

--- a/packages/taco/test/conditions/base/condition.test.ts
+++ b/packages/taco/test/conditions/base/condition.test.ts
@@ -1,19 +1,15 @@
-import { TEST_CHAIN_ID, TEST_CONTRACT_ADDR } from '@nucypher/test-utils';
+import { TEST_CONTRACT_ADDR } from '@nucypher/test-utils';
 import { describe, expect, it } from 'vitest';
 
 import {
   Condition,
   ContractCondition,
-  ERC721Balance,
   ERC721Ownership,
 } from '../../../src/conditions';
-import { testContractConditionObj } from '../../test-utils';
+import { fakeCondition, testContractConditionObj } from '../../test-utils';
 
 describe('validation', () => {
-  const condition = new ERC721Balance({
-    contractAddress: TEST_CONTRACT_ADDR,
-    chain: TEST_CHAIN_ID,
-  });
+  const condition = fakeCondition();
 
   it('accepts a correct schema', async () => {
     const result = Condition.validate(condition.schema, condition.value);

--- a/packages/taco/test/conditions/compound-condition.test.ts
+++ b/packages/taco/test/conditions/compound-condition.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import { CompoundCondition, Condition } from '../../src/conditions';
 import {
-  CompoundConditionType,
   compoundConditionSchema,
+  CompoundConditionType,
 } from '../../src/conditions/compound-condition';
 import {
   testContractConditionObj,

--- a/packages/taco/test/conditions/compound-condition.test.ts
+++ b/packages/taco/test/conditions/compound-condition.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import { CompoundCondition, Condition } from '../../src/conditions';
 import {
-  compoundConditionSchema,
   CompoundConditionType,
+  compoundConditionSchema,
 } from '../../src/conditions/compound-condition';
 import {
   testContractConditionObj,

--- a/packages/taco/test/conditions/condition-expr.test.ts
+++ b/packages/taco/test/conditions/condition-expr.test.ts
@@ -28,6 +28,11 @@ describe('condition set', () => {
   const erc721Balance = new ERC721Balance({
     chain: TEST_CHAIN_ID,
     contractAddress: TEST_CONTRACT_ADDR,
+    returnValueTest: {
+      index: 0,
+      comparator: '>',
+      value: 0,
+    },
   });
 
   const contractConditionNoAbi = new ContractCondition(

--- a/packages/taco/test/dkg-client.test.ts
+++ b/packages/taco/test/dkg-client.test.ts
@@ -19,7 +19,11 @@ describe('DkgCoordinatorAgent', () => {
   it('fetches transcripts from the coordinator', async () => {
     const provider = fakeProvider();
     const getRitualSpy = mockGetRitual();
-    const ritual = await DkgCoordinatorAgent.getRitual(provider, domains.TEST_DOMAIN, fakeRitualId);
+    const ritual = await DkgCoordinatorAgent.getRitual(
+      provider,
+      domains.TEST_DOMAIN,
+      fakeRitualId,
+    );
     expect(ritual).toBeDefined();
     expect(getRitualSpy).toHaveBeenCalled();
   });

--- a/packages/taco/test/dkg-client.test.ts
+++ b/packages/taco/test/dkg-client.test.ts
@@ -2,7 +2,7 @@ import { DkgCoordinatorAgent } from '@nucypher/shared';
 import { fakeProvider } from '@nucypher/test-utils';
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import { initialize } from '../src';
+import { domains, initialize } from '../src';
 
 import {
   fakeRitualId,
@@ -19,7 +19,7 @@ describe('DkgCoordinatorAgent', () => {
   it('fetches transcripts from the coordinator', async () => {
     const provider = fakeProvider();
     const getRitualSpy = mockGetRitual();
-    const ritual = await DkgCoordinatorAgent.getRitual(provider, fakeRitualId);
+    const ritual = await DkgCoordinatorAgent.getRitual(provider, domains.TEST_DOMAIN, fakeRitualId);
     expect(ritual).toBeDefined();
     expect(getRitualSpy).toHaveBeenCalled();
   });
@@ -31,6 +31,7 @@ describe('DkgCoordinatorAgent', () => {
     );
     const participants = await DkgCoordinatorAgent.getParticipants(
       provider,
+      domains.TEST_DOMAIN,
       fakeRitualId,
     );
     expect(getParticipantsSpy).toHaveBeenCalled();

--- a/packages/taco/test/test-utils.ts
+++ b/packages/taco/test/test-utils.ts
@@ -102,8 +102,7 @@ export const fakeDkgTDecFlowE2E: (
   };
 };
 
-export const fakeCoordinatorRitual = async (
-): Promise<CoordinatorRitual> => {
+export const fakeCoordinatorRitual = async (): Promise<CoordinatorRitual> => {
   const ritual = await fakeDkgTDecFlowE2E();
   const dkgPkBytes = ritual.dkg.publicKey().toBytes();
   return {
@@ -117,14 +116,15 @@ export const fakeCoordinatorRitual = async (
     publicKey: {
       word0: toHexString(dkgPkBytes.slice(0, 32)),
       word1: toHexString(dkgPkBytes.slice(32, 48)),
-    } as [string, string] & { // Casting to satisfy the type checker
+    } as [string, string] & {
+      // Casting to satisfy the type checker
       word0: string;
       word1: string;
     },
     endTimestamp: 0,
-    authority: "0x0",
+    authority: '0x0',
     threshold: ritual.threshold,
-    accessController: "0x0",
+    accessController: '0x0',
   };
 };
 
@@ -176,13 +176,9 @@ export const fakeDkgRitual = (ritual: {
 };
 
 export const mockGetRitual = (): SpyInstance => {
-  return vi
-    .spyOn(DkgCoordinatorAgent, 'getRitual')
-    .mockImplementation(
-      () => {
-        return Promise.resolve(fakeCoordinatorRitual());
-      },
-    );
+  return vi.spyOn(DkgCoordinatorAgent, 'getRitual').mockImplementation(() => {
+    return Promise.resolve(fakeCoordinatorRitual());
+  });
 };
 
 export const mockGetFinalizedRitual = (dkgRitual: DkgRitual): SpyInstance => {
@@ -267,13 +263,18 @@ export const testFunctionAbi: FunctionAbiProps = {
   ],
 };
 
-export const fakeConditionExpr = () => {
-  const condition = new ERC721Balance({
+export const fakeCondition = () =>
+  new ERC721Balance({
     chain: TEST_CHAIN_ID,
     contractAddress: TEST_CONTRACT_ADDR,
+    returnValueTest: {
+      index: 0,
+      comparator: '>=',
+      value: 0,
+    },
   });
-  return new ConditionExpression(condition);
-};
+
+export const fakeConditionExpr = () => new ConditionExpression(fakeCondition());
 
 export const mockGetParticipants = (
   participants: DkgParticipant[],

--- a/packages/taco/tsconfig.cjs.json
+++ b/packages/taco/tsconfig.cjs.json
@@ -2,6 +2,6 @@
   "extends": "./tsconfig.es.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "module": "CommonJS",
+    "module": "CommonJS"
   }
 }

--- a/packages/taco/tsconfig.json
+++ b/packages/taco/tsconfig.json
@@ -3,7 +3,7 @@
   "include": ["src", "test", "examples"],
   "compilerOptions": {
     "esModuleInterop": true,
-    "skipLibCheck": true,
+    "skipLibCheck": true
   },
   "references": [
     {

--- a/packages/taco/tsconfig.json
+++ b/packages/taco/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src", "test"],
+  "include": ["src", "test", "examples"],
   "compilerOptions": {
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
**Type of PR:**
-  Documentation

**Required reviews:**
- 1

**What this does:**
- Fixes chores related to code examples used in Gitbook
- Fixes issues with `typedoc` generated docs on GH Pages
- Fixes some type-checking issues that previously went undetected
- Fixes #300 

**Notes for reviewers:**
- `taco/src/examples` are not run at the moment, but are type-checked (compiled) instead - It should catch any issues with the API, but will not catch bugs in `taco`. For that, we implement tests in `taco/test`
- A preview of generated docs is available here: https://nucypher.github.io/nucypher-ts/
