### PR TITLE
Fix  `ConditionContext` not detecting falsy parameters

### DIFF
--- a/packages/taco/src/conditions/context/context.ts
+++ b/packages/taco/src/conditions/context/context.ts
@@ -69,7 +69,7 @@ export class ConditionContext {
     // Ok, so at this point we should have all the parameters we need
     // If we don't, we have a problem and we should throw
     const missingParameters = Array.from(requestedParameters).filter(
-      (key) => !parameters[key],
+      (key) => parameters[key] === undefined,
     );
     if (missingParameters.length > 0) {
       throw new Error(ERR_MISSING_CONTEXT_PARAMS(missingParameters));

--- a/packages/taco/test/conditions/context.test.ts
+++ b/packages/taco/test/conditions/context.test.ts
@@ -200,6 +200,25 @@ describe('context', () => {
         expect(asObj).toBeDefined();
         expect(asObj[USER_ADDRESS_PARAM]).toBeDefined();
       });
+
+      it.each([0, ''])('accepts on a falsy parameter value: %s', async (falsyParam) => {
+        const customParamKey = ':customParam';
+        const customContractCondition = new ContractCondition({
+          ...contractConditionObj,
+          parameters: [USER_ADDRESS_PARAM, customParamKey],
+        });
+        const customParameters: Record<string, CustomContextParam> = {};
+        customParameters[customParamKey] = falsyParam;
+        const conditionContext = new ConditionExpression(
+          customContractCondition,
+        ).buildContext(provider, customParameters, signer);
+
+        const asObj = await conditionContext.toObj();
+        expect(asObj).toBeDefined();
+        expect(asObj[USER_ADDRESS_PARAM]).toBeDefined();
+        expect(asObj[customParamKey]).toBeDefined();
+        expect(asObj[customParamKey]).toEqual(falsyParam);
+      });
     });
   });
 });


### PR DESCRIPTION
**Type of PR:**
- Bugfix

**Required reviews:**
- 1