### PR TITLE
Support `not` operator in `CompoundCondition`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ contracts/compiled
 examples/*/pnpm-lock.yaml
 pnpm-debug.log
 docs-json
-./docs
 .next
+packages/docs
+docs

--- a/demos/taco-demo/src/ConditionBuilder.tsx
+++ b/demos/taco-demo/src/ConditionBuilder.tsx
@@ -9,7 +9,6 @@ interface Props {
 }
 
 const rpcCondition = new conditions.RpcCondition({
-  conditionType: 'rpc',
   chain: Mumbai.chainId,
   method: 'eth_getBalance',
   parameters: [':userAddress'],

--- a/demos/taco-nft-demo/src/NFTConditionBuilder.tsx
+++ b/demos/taco-nft-demo/src/NFTConditionBuilder.tsx
@@ -52,7 +52,6 @@ export const NFTConditionBuilder = ({
   const makeCondition = (): conditions.Condition => {
     if (tokenId) {
       return new conditions.ContractCondition({
-        conditionType: 'contract',
         contractAddress,
         chain,
         standardContractType: 'ERC721',
@@ -65,7 +64,6 @@ export const NFTConditionBuilder = ({
       });
     }
     return new conditions.ContractCondition({
-      conditionType: 'contract',
       contractAddress,
       chain,
       standardContractType: 'ERC721',

--- a/examples/taco/nextjs/src/app/page.tsx
+++ b/examples/taco/nextjs/src/app/page.tsx
@@ -73,7 +73,6 @@ function App() {
 
     console.log('Encrypting message...');
     const hasPositiveBalance = new conditions.RpcCondition({
-      conditionType: 'rpc',
       chain: 5,
       method: 'eth_getBalance',
       parameters: [':userAddress', 'latest'],

--- a/examples/taco/nodejs/src/index.ts
+++ b/examples/taco/nodejs/src/index.ts
@@ -41,7 +41,6 @@ const runExample = async () => {
   const messageString = 'this is a secret';
   const message = toBytes(messageString);
   const hasPositiveBalance = new conditions.RpcCondition({
-    conditionType: 'rpc',
     chain: 80001,
     method: 'eth_getBalance',
     parameters: [':userAddress', 'latest'],

--- a/examples/taco/react/src/App.tsx
+++ b/examples/taco/react/src/App.tsx
@@ -72,7 +72,6 @@ function App() {
 
     console.log('Encrypting message...');
     const hasPositiveBalance = new conditions.RpcCondition({
-      conditionType: 'rpc',
       chain: 5,
       method: 'eth_getBalance',
       parameters: [':userAddress', 'latest'],

--- a/examples/taco/webpack-5/src/index.ts
+++ b/examples/taco/webpack-5/src/index.ts
@@ -35,7 +35,6 @@ const runExample = async () => {
   console.log('Encrypting message...');
   const message = toBytes('this is a secret');
   const hasPositiveBalance = new conditions.RpcCondition({
-    conditionType: 'rpc',
     chain: 5,
     method: 'eth_getBalance',
     parameters: [':userAddress', 'latest'],

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "postinstall": "pnpm build",
     "typedoc": "typedoc",
-    "typedoc:all": "pnpm run --parallel --aggregate-output --reporter append-only typedoc",
-    "typedoc:publish": "gh-pages -m \"[ci skip] Update typedoc docs\" -d docs",
+    "typedoc:publish": "gh-pages -m \"[ci skip] Update typedoc docs\" -d docs --dotfiles",
     "format": "prettier --check \"./**/*.ts\" README.md",
     "format:fix": "prettier --write \"./**/*.ts\" README.md",
     "lint": "pnpm run --parallel --aggregate-output --reporter append-only lint",

--- a/packages/taco/.eslintrc.js
+++ b/packages/taco/.eslintrc.js
@@ -1,5 +1,5 @@
-const baseConfig = require('../../.eslintrc.js')
+const baseConfig = require('../../.eslintrc.js');
 
 module.exports = {
   ...baseConfig,
-}
+};

--- a/packages/taco/README.md
+++ b/packages/taco/README.md
@@ -1,3 +1,60 @@
 # `@nucypher/taco`
 
-## [`nucypher/nucypher-ts`](../../README.md)
+### [`nucypher/nucypher-ts`](../../README.md)
+
+## Usage
+
+First, install the package:
+
+```bash
+$ yarn add @nucypher/taco ethers@5.7.2
+```
+
+### Encrypt your data
+
+```typescript
+import {initialize, encrypt, conditions, domains} from '@nucypher/taco';
+import {ethers} from "ethers";
+
+// We have to initialize the TACo library first
+await initialize();
+
+const web3Provider = new ethers.providers.Web3Provider(window.ethereum);
+
+const ownsNFT = new conditions.predefined.ERC721Ownership({
+  contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
+  parameters: [3591],
+  chain: 5,
+});
+
+const message = "my secret message";
+
+const messageKit = await encrypt(
+  web3Provider,
+  domains.TESTNET,
+  message,
+  ownsNFT,
+  ritualId,
+  web3Provider.getSigner()
+);
+```
+
+### Decrypt your data
+
+```typescript
+import {initialize, decrypt, domains, getPorterUri} from '@nucypher/taco';
+import {ethers} from "ethers";
+
+// We have to initialize the TACo library first
+await initialize();
+
+const web3Provider = new ethers.providers.Web3Provider(window.ethereum);
+
+const decryptedMessage = await decrypt(
+  web3Provider,
+  domains.TESTNET,
+  messageKit,
+  getPorterUri(domains.TESTNET),
+  web3Provider.getSigner()
+);
+```

--- a/packages/taco/README.md
+++ b/packages/taco/README.md
@@ -13,8 +13,8 @@ $ yarn add @nucypher/taco ethers@5.7.2
 ### Encrypt your data
 
 ```typescript
-import {initialize, encrypt, conditions, domains} from '@nucypher/taco';
-import {ethers} from "ethers";
+import { conditions, domains, encrypt, initialize } from '@nucypher/taco';
+import { ethers } from 'ethers';
 
 // We have to initialize the TACo library first
 await initialize();
@@ -27,7 +27,7 @@ const ownsNFT = new conditions.predefined.ERC721Ownership({
   chain: 5,
 });
 
-const message = "my secret message";
+const message = 'my secret message';
 
 const messageKit = await encrypt(
   web3Provider,
@@ -35,15 +35,15 @@ const messageKit = await encrypt(
   message,
   ownsNFT,
   ritualId,
-  web3Provider.getSigner()
+  web3Provider.getSigner(),
 );
 ```
 
 ### Decrypt your data
 
 ```typescript
-import {initialize, decrypt, domains, getPorterUri} from '@nucypher/taco';
-import {ethers} from "ethers";
+import { decrypt, domains, getPorterUri, initialize } from '@nucypher/taco';
+import { ethers } from 'ethers';
 
 // We have to initialize the TACo library first
 await initialize();
@@ -55,6 +55,6 @@ const decryptedMessage = await decrypt(
   domains.TESTNET,
   messageKit,
   getPorterUri(domains.TESTNET),
-  web3Provider.getSigner()
+  web3Provider.getSigner(),
 );
 ```

--- a/packages/taco/examples/README.md
+++ b/packages/taco/examples/README.md
@@ -1,0 +1,5 @@
+# `examples/taco`
+
+These examples are not tested, but are typechecked with `pnpm type-check` instead.
+
+Some of these examples are used in the documentation. Others, are provided as an API reference.

--- a/packages/taco/examples/README.md
+++ b/packages/taco/examples/README.md
@@ -1,5 +1,7 @@
 # `examples/taco`
 
-These examples are not tested, but are typechecked with `pnpm type-check` instead.
+These examples are not tested, but are typechecked with `pnpm type-check`
+instead.
 
-Some of these examples are used in the documentation. Others, are provided as an API reference.
+Some of these examples are used in the documentation. Others, are provided as an
+API reference.

--- a/packages/taco/examples/conditions.ts
+++ b/packages/taco/examples/conditions.ts
@@ -72,12 +72,55 @@ const hasAnyNativeAssetOnChain1 = new conditions.base.RpcCondition({
   },
 });
 
-const multichainCondition = new conditions.base.CompoundCondition({
-  operator: 'and',
-  operands: [ownsNFTOnChain5, hasAnyNativeAssetOnChain1],
-});
+const multichainCondition = conditions.base.CompoundCondition.and([
+  ownsNFTOnChain5,
+  hasAnyNativeAssetOnChain1,
+]);
 
 console.assert(
   multichainCondition.requiresSigner(),
   'CompoundCondition requires signer',
+);
+
+const myFunctionAbi: conditions.FunctionAbiProps = {
+  name: 'myFunction',
+  type: 'function',
+  stateMutability: 'view',
+  inputs: [
+    {
+      internalType: 'address',
+      name: 'account',
+      type: 'address',
+    },
+    {
+      internalType: 'uint256',
+      name: 'myCustomParam',
+      type: 'uint256',
+    },
+  ],
+  outputs: [
+    {
+      internalType: 'uint256',
+      name: 'someValue',
+      type: 'uint256',
+    },
+  ],
+};
+
+const myContractCallCondition = new conditions.base.ContractCondition({
+  method: 'myFunctionAbi', // `myMethodAbi.name`
+  parameters: [':userAddress', ':myCustomParam'], // `myMethodAbi.inputs`
+  functionAbi: myFunctionAbi,
+  contractAddress: '0x0...1',
+  chain: 5,
+  returnValueTest: {
+    index: 0,
+    comparator: '>',
+    value: 0,
+  },
+});
+
+console.assert(
+  !myContractCallCondition.requiresSigner(),
+  'ContractCondition does not require a signer',
 );

--- a/packages/taco/examples/conditions.ts
+++ b/packages/taco/examples/conditions.ts
@@ -24,7 +24,6 @@ console.assert(
 
 const ownsNFTRaw = new conditions.base.ContractCondition({
   // Provided by the `predefined.ERC721Balance`
-  conditionType: ContractConditionType,
   method: 'balanceOf',
   parameters: [':userAddress'],
   standardContractType: 'ERC721',
@@ -43,7 +42,6 @@ console.assert(
 );
 
 const hasAnyNativeAsset = new conditions.base.RpcCondition({
-  conditionType: 'rpc',
   chain: 5,
   method: 'eth_getBalance',
   parameters: [':userAddress'],
@@ -65,7 +63,6 @@ const ownsNFTOnChain5 = new conditions.predefined.ERC721Ownership({
 });
 
 const hasAnyNativeAssetOnChain1 = new conditions.base.RpcCondition({
-  conditionType: 'rpc',
   chain: 1, // The second network we target
   method: 'eth_getBalance',
   parameters: [':userAddress'],
@@ -77,7 +74,6 @@ const hasAnyNativeAssetOnChain1 = new conditions.base.RpcCondition({
 });
 
 const multichainCondition = new conditions.base.CompoundCondition({
-  conditionType: 'compound',
   operator: 'and',
   operands: [ownsNFTOnChain5, hasAnyNativeAssetOnChain1],
 });

--- a/packages/taco/examples/conditions.ts
+++ b/packages/taco/examples/conditions.ts
@@ -1,5 +1,4 @@
 import { conditions } from '../src';
-import { ContractConditionType } from '../src/conditions';
 
 const ownsNFT = new conditions.predefined.ERC721Ownership({
   contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',

--- a/packages/taco/examples/conditions.ts
+++ b/packages/taco/examples/conditions.ts
@@ -1,0 +1,57 @@
+import { conditions } from '../src';
+import { ContractConditionType } from '../src/conditions';
+import { USER_ADDRESS_PARAM } from '../src/conditions/const';
+
+const ownsNFT = new conditions.predefined.ERC721Ownership({
+  contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
+  parameters: [3591],
+  chain: 5,
+});
+console.assert(ownsNFT.requiresSigner(), 'ERC721Ownership requires signer');
+
+const hasAtLeastTwoNFTs = new conditions.predefined.ERC721Balance({
+  contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
+  chain: 5,
+  returnValueTest: {
+    index: 0,
+    comparator: '>=',
+    value: 2,
+  },
+});
+console.assert(
+  hasAtLeastTwoNFTs.requiresSigner(),
+  'ERC721Balance requires signer',
+);
+
+const ownsNFTRaw = new conditions.base.ContractCondition({
+  // Provided by the `predefined.ERC721Balance`
+  conditionType: ContractConditionType,
+  method: 'balanceOf',
+  parameters: [USER_ADDRESS_PARAM], // ':userAddress'
+  standardContractType: 'ERC721',
+  // User-provided
+  contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
+  chain: 5,
+  returnValueTest: {
+    index: 0,
+    comparator: '>',
+    value: 0,
+  },
+});
+console.assert(ownsNFTRaw.requiresSigner(), 'ContractCondition requires signer');
+
+const hasAnyNativeAsset = new conditions.base.RpcCondition({
+  conditionType: 'rpc',
+  chain: 5,
+  method: 'eth_getBalance',
+  parameters: [':userAddress'],
+  returnValueTest: {
+    index: 0,
+    comparator: '>',
+    value: 0,
+  },
+});
+console.assert(
+  hasAnyNativeAsset.requiresSigner(),
+  'RpcCondition requires signer',
+);

--- a/packages/taco/examples/conditions.ts
+++ b/packages/taco/examples/conditions.ts
@@ -38,7 +38,10 @@ const ownsNFTRaw = new conditions.base.ContractCondition({
     value: 0,
   },
 });
-console.assert(ownsNFTRaw.requiresSigner(), 'ContractCondition requires signer');
+console.assert(
+  ownsNFTRaw.requiresSigner(),
+  'ContractCondition requires signer',
+);
 
 const hasAnyNativeAsset = new conditions.base.RpcCondition({
   conditionType: 'rpc',

--- a/packages/taco/examples/conditions.ts
+++ b/packages/taco/examples/conditions.ts
@@ -1,6 +1,5 @@
 import { conditions } from '../src';
 import { ContractConditionType } from '../src/conditions';
-import { USER_ADDRESS_PARAM } from '../src/conditions/const';
 
 const ownsNFT = new conditions.predefined.ERC721Ownership({
   contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
@@ -27,7 +26,7 @@ const ownsNFTRaw = new conditions.base.ContractCondition({
   // Provided by the `predefined.ERC721Balance`
   conditionType: ContractConditionType,
   method: 'balanceOf',
-  parameters: [USER_ADDRESS_PARAM], // ':userAddress'
+  parameters: [':userAddress'],
   standardContractType: 'ERC721',
   // User-provided
   contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
@@ -40,7 +39,7 @@ const ownsNFTRaw = new conditions.base.ContractCondition({
 });
 console.assert(
   ownsNFTRaw.requiresSigner(),
-  'ContractCondition requires signer',
+  'ContractCondition requires a signer',
 );
 
 const hasAnyNativeAsset = new conditions.base.RpcCondition({
@@ -57,4 +56,33 @@ const hasAnyNativeAsset = new conditions.base.RpcCondition({
 console.assert(
   hasAnyNativeAsset.requiresSigner(),
   'RpcCondition requires signer',
+);
+
+const ownsNFTOnChain5 = new conditions.predefined.ERC721Ownership({
+  contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
+  parameters: [3591],
+  chain: 5, // The first network we target
+});
+
+const hasAnyNativeAssetOnChain1 = new conditions.base.RpcCondition({
+  conditionType: 'rpc',
+  chain: 1, // The second network we target
+  method: 'eth_getBalance',
+  parameters: [':userAddress'],
+  returnValueTest: {
+    index: 0,
+    comparator: '>',
+    value: 0,
+  },
+});
+
+const multichainCondition = new conditions.base.CompoundCondition({
+  conditionType: 'compound',
+  operator: 'and',
+  operands: [ownsNFTOnChain5, hasAnyNativeAssetOnChain1],
+});
+
+console.assert(
+  multichainCondition.requiresSigner(),
+  'CompoundCondition requires signer',
 );

--- a/packages/taco/examples/context.ts
+++ b/packages/taco/examples/context.ts
@@ -1,6 +1,5 @@
 import { conditions } from '../src';
-import {CustomContextParam} from "../src/conditions";
-
+import { CustomContextParam } from '../src/conditions';
 
 const ownsNFTRaw = new conditions.base.ContractCondition({
   method: 'balanceOf',
@@ -14,8 +13,10 @@ const ownsNFTRaw = new conditions.base.ContractCondition({
     value: ':selectedBalance',
   },
 });
-console.assert(ownsNFTRaw.requiresSigner(), 'ContractCondition requires a signer');
-
+console.assert(
+  ownsNFTRaw.requiresSigner(),
+  'ContractCondition requires a signer',
+);
 
 const customParameters: Record<string, CustomContextParam> = {
   ':selectedBalance': 2,

--- a/packages/taco/examples/context.ts
+++ b/packages/taco/examples/context.ts
@@ -1,0 +1,23 @@
+import { conditions } from '../src';
+import {CustomContextParam} from "../src/conditions";
+
+
+const ownsNFTRaw = new conditions.base.ContractCondition({
+  method: 'balanceOf',
+  parameters: [':userAddress'],
+  standardContractType: 'ERC721',
+  contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
+  chain: 5,
+  returnValueTest: {
+    index: 0,
+    comparator: '>',
+    value: ':selectedBalance',
+  },
+});
+console.assert(ownsNFTRaw.requiresSigner(), 'ContractCondition requires a signer');
+
+
+const customParameters: Record<string, CustomContextParam> = {
+  ':selectedBalance': 2,
+};
+console.log(customParameters);

--- a/packages/taco/examples/encrypt-decrypt.ts
+++ b/packages/taco/examples/encrypt-decrypt.ts
@@ -1,0 +1,66 @@
+import { ethers } from 'ethers';
+
+import {
+  conditions,
+  decrypt,
+  domains,
+  encrypt,
+  getPorterUri,
+  initialize,
+  ThresholdMessageKit,
+  toBytes,
+} from '../src';
+
+const ritualId = 1;
+
+const run = async () => {
+  // The data encryptor runs this part
+  const doEncrypt = async (message: string) => {
+    // We have to initialize TACo library first
+    await initialize();
+
+    // @ts-ignore
+    const web3Provider = new ethers.providers.Web3Provider(window.ethereum);
+    const ownsNFT = new conditions.predefined.ERC721Ownership({
+      contractAddress: '0x1e988ba4692e52Bc50b375bcC8585b95c48AaD77',
+      parameters: [3591],
+      chain: 5,
+    });
+    const messageKit = await encrypt(
+      web3Provider,
+      domains.TESTNET,
+      message,
+      ownsNFT,
+      ritualId,
+      web3Provider.getSigner(),
+    );
+    return messageKit;
+  };
+
+  // The data recipient runs this part
+  const doDecrypt = async (messageKit: ThresholdMessageKit) => {
+    // We have to initialize TACo library first
+    await initialize();
+
+    // @ts-ignore
+    const web3Provider = new ethers.providers.Web3Provider(window.ethereum);
+    const decryptedMessage = await decrypt(
+      web3Provider,
+      domains.TESTNET,
+      messageKit,
+      getPorterUri(domains.TESTNET),
+      web3Provider.getSigner(),
+    );
+    return decryptedMessage;
+  };
+
+  const message = 'my secret message';
+  const encryptedMessage = await doEncrypt(message);
+  const decryptedMessage = await doDecrypt(encryptedMessage);
+
+  if (decryptedMessage === toBytes(message)) {
+    console.log('Success!');
+  }
+};
+
+run();

--- a/packages/taco/package.json
+++ b/packages/taco/package.json
@@ -35,6 +35,7 @@
     "lint:fix": "pnpm lint --fix",
     "package-check": "package-check",
     "test": "vitest run",
+    "type-check": "tsc --noEmit",
     "typedoc": "typedoc"
   },
   "dependencies": {

--- a/packages/taco/src/conditions/base/contract.ts
+++ b/packages/taco/src/conditions/base/contract.ts
@@ -74,7 +74,7 @@ export const contractConditionSchema = rpcConditionSchema
     conditionType: z
       .literal(ContractConditionType)
       .default(ContractConditionType),
-    contractAddress: z.string().regex(ETH_ADDRESS_REGEXP),
+    contractAddress: z.string().regex(ETH_ADDRESS_REGEXP).length(42),
     standardContractType: z.enum(['ERC20', 'ERC721']).optional(),
     method: z.string(),
     functionAbi: functionAbiSchema.optional(),

--- a/packages/taco/src/conditions/base/contract.ts
+++ b/packages/taco/src/conditions/base/contract.ts
@@ -50,6 +50,7 @@ const functionAbiSchema = z
     },
     {
       message: '"functionAbi" must contain a single function definition',
+      path: ['functionAbi'],
     },
   )
   .refine(
@@ -62,6 +63,7 @@ const functionAbiSchema = z
     },
     {
       message: '"parameters" must have the same length as "functionAbi.inputs"',
+      path: ['parameters'],
     },
   );
 
@@ -88,6 +90,7 @@ export const contractConditionSchema = rpcConditionSchema
     {
       message:
         "At most one of the fields 'standardContractType' and 'functionAbi' must be defined",
+      path: ['standardContractType'],
     },
   );
 

--- a/packages/taco/src/conditions/base/index.ts
+++ b/packages/taco/src/conditions/base/index.ts
@@ -5,14 +5,24 @@ import {
 } from '../compound-condition';
 import { Condition, ConditionProps } from '../condition';
 
-import { ContractConditionProps, contractConditionSchema, ContractConditionType } from './contract';
+import {
+  ContractConditionProps,
+  contractConditionSchema,
+  ContractConditionType,
+} from './contract';
 import { RpcConditionProps, rpcConditionSchema, RpcConditionType } from './rpc';
-import { TimeConditionProps, timeConditionSchema, TimeConditionType } from './time';
+import {
+  TimeConditionProps,
+  timeConditionSchema,
+  TimeConditionType,
+} from './time';
 
-type OmitConditionType<T> = Omit<T, 'conditionType'>
+type OmitConditionType<T> = Omit<T, 'conditionType'>;
 
 // Exporting classes here instead of their respective schema files to
 // avoid circular dependency on Condition class.
+
+type ConditionOrProps = Condition | ConditionProps;
 
 export class CompoundCondition extends Condition {
   constructor(value: OmitConditionType<CompoundConditionProps>) {
@@ -23,20 +33,26 @@ export class CompoundCondition extends Condition {
   }
 
   private static withOperator(
-    operands: ConditionProps[],
+    operands: ConditionOrProps[],
     operator: 'or' | 'and',
   ): CompoundCondition {
+    const asObjects = operands.map((operand) => {
+      if (operand instanceof Condition) {
+        return operand.toObj();
+      }
+      return operand;
+    });
     return new CompoundCondition({
       operator,
-      operands,
+      operands: asObjects,
     });
   }
 
-  public static or(conditions: ConditionProps[]): CompoundCondition {
+  public static or(conditions: ConditionOrProps[]): CompoundCondition {
     return CompoundCondition.withOperator(conditions, 'or');
   }
 
-  public static and(conditions: ConditionProps[]): CompoundCondition {
+  public static and(conditions: ConditionOrProps[]): CompoundCondition {
     return CompoundCondition.withOperator(conditions, 'and');
   }
 }
@@ -45,7 +61,7 @@ export class ContractCondition extends Condition {
   constructor(value: OmitConditionType<ContractConditionProps>) {
     super(contractConditionSchema, {
       conditionType: ContractConditionType,
-      ...value
+      ...value,
     });
   }
 }
@@ -54,7 +70,7 @@ export class RpcCondition extends Condition {
   constructor(value: OmitConditionType<RpcConditionProps>) {
     super(rpcConditionSchema, {
       conditionType: RpcConditionType,
-      ...value
+      ...value,
     });
   }
 }
@@ -63,7 +79,7 @@ export class TimeCondition extends Condition {
   constructor(value: OmitConditionType<TimeConditionProps>) {
     super(timeConditionSchema, {
       conditionType: TimeConditionType,
-      ...value
+      ...value,
     });
   }
 }

--- a/packages/taco/src/conditions/base/index.ts
+++ b/packages/taco/src/conditions/base/index.ts
@@ -5,16 +5,21 @@ import {
 } from '../compound-condition';
 import { Condition, ConditionProps } from '../condition';
 
-import { ContractConditionProps, contractConditionSchema } from './contract';
-import { RpcConditionProps, rpcConditionSchema } from './rpc';
-import { TimeConditionProps, timeConditionSchema } from './time';
+import { ContractConditionProps, contractConditionSchema, ContractConditionType } from './contract';
+import { RpcConditionProps, rpcConditionSchema, RpcConditionType } from './rpc';
+import { TimeConditionProps, timeConditionSchema, TimeConditionType } from './time';
+
+type OmitType<T> = Omit<T, 'conditionType'>
 
 // Exporting classes here instead of their respective schema files to
 // avoid circular dependency on Condition class.
 
 export class CompoundCondition extends Condition {
-  constructor(value: CompoundConditionProps) {
-    super(compoundConditionSchema, value);
+  constructor(value: OmitType<CompoundConditionProps>) {
+    super(compoundConditionSchema, {
+      conditionType: CompoundConditionType,
+      ...value,
+    });
   }
 
   private static withOperator(
@@ -22,7 +27,6 @@ export class CompoundCondition extends Condition {
     operator: 'or' | 'and',
   ): CompoundCondition {
     return new CompoundCondition({
-      conditionType: CompoundConditionType,
       operator,
       operands,
     });
@@ -38,20 +42,29 @@ export class CompoundCondition extends Condition {
 }
 
 export class ContractCondition extends Condition {
-  constructor(value: ContractConditionProps) {
-    super(contractConditionSchema, value);
+  constructor(value: OmitType<ContractConditionProps>) {
+    super(contractConditionSchema, {
+      conditionType: ContractConditionType,
+      ...value
+    });
   }
 }
 
 export class RpcCondition extends Condition {
-  constructor(value: RpcConditionProps) {
-    super(rpcConditionSchema, value);
+  constructor(value: OmitType<RpcConditionProps>) {
+    super(rpcConditionSchema, {
+      conditionType: RpcConditionType,
+      ...value
+    });
   }
 }
 
 export class TimeCondition extends Condition {
-  constructor(value: TimeConditionProps) {
-    super(timeConditionSchema, value);
+  constructor(value: OmitType<TimeConditionProps>) {
+    super(timeConditionSchema, {
+      conditionType: TimeConditionType,
+      ...value
+    });
   }
 }
 

--- a/packages/taco/src/conditions/base/index.ts
+++ b/packages/taco/src/conditions/base/index.ts
@@ -9,13 +9,13 @@ import { ContractConditionProps, contractConditionSchema, ContractConditionType 
 import { RpcConditionProps, rpcConditionSchema, RpcConditionType } from './rpc';
 import { TimeConditionProps, timeConditionSchema, TimeConditionType } from './time';
 
-type OmitType<T> = Omit<T, 'conditionType'>
+type OmitConditionType<T> = Omit<T, 'conditionType'>
 
 // Exporting classes here instead of their respective schema files to
 // avoid circular dependency on Condition class.
 
 export class CompoundCondition extends Condition {
-  constructor(value: OmitType<CompoundConditionProps>) {
+  constructor(value: OmitConditionType<CompoundConditionProps>) {
     super(compoundConditionSchema, {
       conditionType: CompoundConditionType,
       ...value,
@@ -42,7 +42,7 @@ export class CompoundCondition extends Condition {
 }
 
 export class ContractCondition extends Condition {
-  constructor(value: OmitType<ContractConditionProps>) {
+  constructor(value: OmitConditionType<ContractConditionProps>) {
     super(contractConditionSchema, {
       conditionType: ContractConditionType,
       ...value
@@ -51,7 +51,7 @@ export class ContractCondition extends Condition {
 }
 
 export class RpcCondition extends Condition {
-  constructor(value: OmitType<RpcConditionProps>) {
+  constructor(value: OmitConditionType<RpcConditionProps>) {
     super(rpcConditionSchema, {
       conditionType: RpcConditionType,
       ...value
@@ -60,7 +60,7 @@ export class RpcCondition extends Condition {
 }
 
 export class TimeCondition extends Condition {
-  constructor(value: OmitType<TimeConditionProps>) {
+  constructor(value: OmitConditionType<TimeConditionProps>) {
     super(timeConditionSchema, {
       conditionType: TimeConditionType,
       ...value

--- a/packages/taco/src/conditions/base/index.ts
+++ b/packages/taco/src/conditions/base/index.ts
@@ -1,8 +1,9 @@
 import {
   CompoundConditionProps,
   compoundConditionSchema,
+  CompoundConditionType,
 } from '../compound-condition';
-import { Condition } from '../condition';
+import { Condition, ConditionProps } from '../condition';
 
 import { ContractConditionProps, contractConditionSchema } from './contract';
 import { RpcConditionProps, rpcConditionSchema } from './rpc';
@@ -14,6 +15,25 @@ import { TimeConditionProps, timeConditionSchema } from './time';
 export class CompoundCondition extends Condition {
   constructor(value: CompoundConditionProps) {
     super(compoundConditionSchema, value);
+  }
+
+  private static withOperator(
+    operands: ConditionProps[],
+    operator: 'or' | 'and',
+  ): CompoundCondition {
+    return new CompoundCondition({
+      conditionType: CompoundConditionType,
+      operator,
+      operands,
+    });
+  }
+
+  public static or(conditions: ConditionProps[]): CompoundCondition {
+    return CompoundCondition.withOperator(conditions, 'or');
+  }
+
+  public static and(conditions: ConditionProps[]): CompoundCondition {
+    return CompoundCondition.withOperator(conditions, 'and');
   }
 }
 

--- a/packages/taco/src/conditions/base/index.ts
+++ b/packages/taco/src/conditions/base/index.ts
@@ -34,7 +34,7 @@ export class CompoundCondition extends Condition {
 
   private static withOperator(
     operands: ConditionOrProps[],
-    operator: 'or' | 'and',
+    operator: 'or' | 'and' | 'not',
   ): CompoundCondition {
     const asObjects = operands.map((operand) => {
       if (operand instanceof Condition) {
@@ -54,6 +54,10 @@ export class CompoundCondition extends Condition {
 
   public static and(conditions: ConditionOrProps[]): CompoundCondition {
     return CompoundCondition.withOperator(conditions, 'and');
+  }
+
+  public static not(condition: ConditionOrProps): CompoundCondition {
+    return CompoundCondition.withOperator([condition], 'not');
   }
 }
 

--- a/packages/taco/src/conditions/compound-condition.ts
+++ b/packages/taco/src/conditions/compound-condition.ts
@@ -6,23 +6,45 @@ import { timeConditionSchema } from './base/time';
 
 export const CompoundConditionType = 'compound';
 
-export const compoundConditionSchema: z.ZodSchema = z.object({
-  conditionType: z
-    .literal(CompoundConditionType)
-    .default(CompoundConditionType),
-  operator: z.enum(['and', 'or']),
-  operands: z
-    .array(
-      z.lazy(() =>
-        z.union([
-          rpcConditionSchema,
-          timeConditionSchema,
-          contractConditionSchema,
-          compoundConditionSchema,
-        ]),
-      ),
-    )
-    .min(2),
-});
+export const compoundConditionSchema: z.ZodSchema = z
+  .object({
+    conditionType: z
+      .literal(CompoundConditionType)
+      .default(CompoundConditionType),
+    operator: z.enum(['and', 'or', 'not']),
+    operands: z
+      .array(
+        z.lazy(() =>
+          z.union([
+            rpcConditionSchema,
+            timeConditionSchema,
+            contractConditionSchema,
+            compoundConditionSchema,
+          ]),
+        ),
+      )
+      .min(1),
+  })
+  .refine(
+    (condition) => {
+      // 'and' and 'or' operators must have at least 2 operands
+      if (['and', 'or'].includes(condition.operator)) {
+        return condition.operands.length >= 2;
+      }
+
+      // 'not' operator must have exactly 1 operand
+      if (condition.operator === 'not') {
+        return condition.operands.length === 1;
+      }
+
+      // We test positive cases exhaustively, so we return false here:
+      return false;
+    },
+    ({ operands, operator  }) => ({
+        message: `Invalid number of operands ${operands.length} for operator "${operator}"`,
+        path: ['operands'],
+    })
+  );
+
 
 export type CompoundConditionProps = z.infer<typeof compoundConditionSchema>;

--- a/packages/taco/src/conditions/predefined/erc721.ts
+++ b/packages/taco/src/conditions/predefined/erc721.ts
@@ -27,7 +27,7 @@ export class ERC721Ownership extends ContractCondition {
   }
 }
 
-type ERC721BalanceFields = 'contractAddress' | 'chain';
+type ERC721BalanceFields = 'contractAddress' | 'chain' | 'returnValueTest';
 
 const ERC721BalanceDefaults: Omit<ContractConditionProps, ERC721BalanceFields> =
   {
@@ -35,11 +35,6 @@ const ERC721BalanceDefaults: Omit<ContractConditionProps, ERC721BalanceFields> =
     method: 'balanceOf',
     parameters: [USER_ADDRESS_PARAM],
     standardContractType: 'ERC721',
-    returnValueTest: {
-      index: 0,
-      comparator: '>',
-      value: '0',
-    },
   };
 
 export class ERC721Balance extends ContractCondition {

--- a/packages/taco/test/conditions/base/condition.test.ts
+++ b/packages/taco/test/conditions/base/condition.test.ts
@@ -1,19 +1,15 @@
-import { TEST_CHAIN_ID, TEST_CONTRACT_ADDR } from '@nucypher/test-utils';
+import { TEST_CONTRACT_ADDR } from '@nucypher/test-utils';
 import { describe, expect, it } from 'vitest';
 
 import {
   Condition,
   ContractCondition,
-  ERC721Balance,
   ERC721Ownership,
 } from '../../../src/conditions';
-import { testContractConditionObj } from '../../test-utils';
+import { fakeCondition, testContractConditionObj } from '../../test-utils';
 
 describe('validation', () => {
-  const condition = new ERC721Balance({
-    contractAddress: TEST_CONTRACT_ADDR,
-    chain: TEST_CHAIN_ID,
-  });
+  const condition = fakeCondition();
 
   it('accepts a correct schema', async () => {
     const result = Condition.validate(condition.schema, condition.value);

--- a/packages/taco/test/conditions/base/contract.test.ts
+++ b/packages/taco/test/conditions/base/contract.test.ts
@@ -119,9 +119,11 @@ describe('accepts either standardContractType or functionAbi but not both or non
     expect(result.error).toBeDefined();
     expect(result.data).toBeUndefined();
     expect(result.error?.format()).toMatchObject({
-      _errors: [
-        "At most one of the fields 'standardContractType' and 'functionAbi' must be defined",
-      ],
+      standardContractType: {
+        _errors: [
+          "At most one of the fields 'standardContractType' and 'functionAbi' must be defined",
+        ],
+      },
     });
   });
 
@@ -139,9 +141,11 @@ describe('accepts either standardContractType or functionAbi but not both or non
     expect(result.error).toBeDefined();
     expect(result.data).toBeUndefined();
     expect(result.error?.format()).toMatchObject({
-      _errors: [
-        "At most one of the fields 'standardContractType' and 'functionAbi' must be defined",
-      ],
+      standardContractType: {
+        _errors: [
+          "At most one of the fields 'standardContractType' and 'functionAbi' must be defined",
+        ],
+      },
     });
   });
 });

--- a/packages/taco/test/conditions/base/contract.test.ts
+++ b/packages/taco/test/conditions/base/contract.test.ts
@@ -45,7 +45,9 @@ describe('validation', () => {
   });
 
   it('infers condition type from constructor', ()=> {
-    const condition = new ContractCondition(testContractConditionObj);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { conditionType, ...withoutType } = testContractConditionObj;
+    const condition = new ContractCondition(withoutType);
     expect(condition.value.conditionType).toEqual(ContractConditionType);
   })
 });

--- a/packages/taco/test/conditions/base/contract.test.ts
+++ b/packages/taco/test/conditions/base/contract.test.ts
@@ -5,7 +5,8 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import {
   ConditionExpression,
   ContractCondition,
-  ContractConditionProps, ContractConditionType,
+  ContractConditionProps,
+  ContractConditionType,
   CustomContextParam,
   FunctionAbiProps,
 } from '../../../src/conditions';
@@ -44,12 +45,12 @@ describe('validation', () => {
     });
   });
 
-  it('infers condition type from constructor', ()=> {
+  it('infers condition type from constructor', () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { conditionType, ...withoutType } = testContractConditionObj;
     const condition = new ContractCondition(withoutType);
     expect(condition.value.conditionType).toEqual(ContractConditionType);
-  })
+  });
 });
 
 describe('accepts either standardContractType or functionAbi but not both or none', () => {

--- a/packages/taco/test/conditions/base/contract.test.ts
+++ b/packages/taco/test/conditions/base/contract.test.ts
@@ -5,7 +5,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import {
   ConditionExpression,
   ContractCondition,
-  ContractConditionProps,
+  ContractConditionProps, ContractConditionType,
   CustomContextParam,
   FunctionAbiProps,
 } from '../../../src/conditions';
@@ -43,6 +43,11 @@ describe('validation', () => {
       },
     });
   });
+
+  it('infers condition type from constructor', ()=> {
+    const condition = new ContractCondition(testContractConditionObj);
+    expect(condition.value.conditionType).toEqual(ContractConditionType);
+  })
 });
 
 describe('accepts either standardContractType or functionAbi but not both or none', () => {

--- a/packages/taco/test/conditions/base/rpc.test.ts
+++ b/packages/taco/test/conditions/base/rpc.test.ts
@@ -1,7 +1,7 @@
 import { TEST_CONTRACT_ADDR } from '@nucypher/test-utils';
 import { describe, expect, it } from 'vitest';
 
-import {RpcCondition, RpcConditionType} from '../../../src/conditions';
+import { RpcCondition, RpcConditionType } from '../../../src/conditions';
 import { rpcConditionSchema } from '../../../src/conditions/base/rpc';
 import { testRpcConditionObj } from '../../test-utils';
 
@@ -36,7 +36,9 @@ describe('validation', () => {
     });
   });
 
-  it ('infers condition type from constructor', () => {
+  it('infers condition type from constructor', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { conditionType, ...withoutType } = testRpcConditionObj;
     const condition = new RpcCondition(testRpcConditionObj);
     expect(condition.value.conditionType).toEqual(RpcConditionType);
   });

--- a/packages/taco/test/conditions/base/rpc.test.ts
+++ b/packages/taco/test/conditions/base/rpc.test.ts
@@ -1,7 +1,7 @@
 import { TEST_CONTRACT_ADDR } from '@nucypher/test-utils';
 import { describe, expect, it } from 'vitest';
 
-import { RpcCondition } from '../../../src/conditions';
+import {RpcCondition, RpcConditionType} from '../../../src/conditions';
 import { rpcConditionSchema } from '../../../src/conditions/base/rpc';
 import { testRpcConditionObj } from '../../test-utils';
 
@@ -34,6 +34,11 @@ describe('validation', () => {
         ],
       },
     });
+  });
+
+  it ('infers condition type from constructor', () => {
+    const condition = new RpcCondition(testRpcConditionObj);
+    expect(condition.value.conditionType).toEqual(RpcConditionType);
   });
 
   describe('parameters', () => {

--- a/packages/taco/test/conditions/base/time.test.ts
+++ b/packages/taco/test/conditions/base/time.test.ts
@@ -53,4 +53,14 @@ describe('validation', () => {
       },
     });
   });
+
+  it('infers condition type from constructor', () => {
+    const condition = new TimeCondition({
+      returnValueTest,
+      method: TimeConditionMethod,
+      chain: 5,
+    });
+    expect(condition.value.conditionType).toEqual(TimeConditionType);
+  });
+
 });

--- a/packages/taco/test/conditions/base/time.test.ts
+++ b/packages/taco/test/conditions/base/time.test.ts
@@ -62,5 +62,4 @@ describe('validation', () => {
     });
     expect(condition.value.conditionType).toEqual(TimeConditionType);
   });
-
 });

--- a/packages/taco/test/conditions/compound-condition.test.ts
+++ b/packages/taco/test/conditions/compound-condition.test.ts
@@ -28,7 +28,6 @@ describe('validation', () => {
 
   it('accepts and operator', () => {
     const conditionObj = {
-      conditionType: CompoundConditionType,
       operator: 'and',
       operands: [testContractConditionObj, testTimeConditionObj],
     };
@@ -189,5 +188,13 @@ describe('validation', () => {
       operator: 'and',
       operands: [testContractConditionObj, testTimeConditionObj],
     });
+  });
+
+  it('infers condition type from constructor', () => {
+    const condition = new CompoundCondition({
+      operator: 'and',
+      operands: [testContractConditionObj, testTimeConditionObj],
+    });
+    expect(condition.value.conditionType).toEqual(CompoundConditionType);
   });
 });

--- a/packages/taco/test/conditions/compound-condition.test.ts
+++ b/packages/taco/test/conditions/compound-condition.test.ts
@@ -23,7 +23,10 @@ describe('validation', () => {
       operator,
       operands: [testContractConditionObj, testTimeConditionObj],
     };
-    const result = CompoundCondition.validate(compoundConditionSchema, conditionObj);
+    const result = CompoundCondition.validate(
+      compoundConditionSchema,
+      conditionObj,
+    );
 
     expect(result.error).toBeUndefined();
     expect(result.data).toEqual({

--- a/packages/taco/test/conditions/compound-condition.test.ts
+++ b/packages/taco/test/conditions/compound-condition.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import { CompoundCondition, Condition } from '../../src/conditions';
 import {
-  CompoundConditionType,
   compoundConditionSchema,
+  CompoundConditionType,
 } from '../../src/conditions/compound-condition';
 import {
   testContractConditionObj,

--- a/packages/taco/test/conditions/compound-condition.test.ts
+++ b/packages/taco/test/conditions/compound-condition.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import { CompoundCondition, Condition } from '../../src/conditions';
 import {
-  compoundConditionSchema,
   CompoundConditionType,
+  compoundConditionSchema,
 } from '../../src/conditions/compound-condition';
 import {
   testContractConditionObj,

--- a/packages/taco/test/conditions/compound-condition.test.ts
+++ b/packages/taco/test/conditions/compound-condition.test.ts
@@ -166,4 +166,28 @@ describe('validation', () => {
     expect(result.error).toBeDefined();
     expect(result.data).toBeUndefined();
   });
+
+  it('accepts shorthand for "or" operator', () => {
+    const compoundCondition = CompoundCondition.or([
+      testContractConditionObj,
+      testTimeConditionObj,
+    ]);
+    expect(compoundCondition.toObj()).toEqual({
+      conditionType: CompoundConditionType,
+      operator: 'or',
+      operands: [testContractConditionObj, testTimeConditionObj],
+    });
+  });
+
+  it('accepts shorthand for "and" operator', () => {
+    const compoundCondition = CompoundCondition.and([
+      testContractConditionObj,
+      testTimeConditionObj,
+    ]);
+    expect(compoundCondition.toObj()).toEqual({
+      conditionType: CompoundConditionType,
+      operator: 'and',
+      operands: [testContractConditionObj, testTimeConditionObj],
+    });
+  });
 });

--- a/packages/taco/test/conditions/condition-expr.test.ts
+++ b/packages/taco/test/conditions/condition-expr.test.ts
@@ -28,6 +28,11 @@ describe('condition set', () => {
   const erc721Balance = new ERC721Balance({
     chain: TEST_CHAIN_ID,
     contractAddress: TEST_CONTRACT_ADDR,
+    returnValueTest: {
+      index: 0,
+      comparator: '>',
+      value: 0,
+    },
   });
 
   const contractConditionNoAbi = new ContractCondition(

--- a/packages/taco/test/dkg-client.test.ts
+++ b/packages/taco/test/dkg-client.test.ts
@@ -19,7 +19,11 @@ describe('DkgCoordinatorAgent', () => {
   it('fetches transcripts from the coordinator', async () => {
     const provider = fakeProvider();
     const getRitualSpy = mockGetRitual();
-    const ritual = await DkgCoordinatorAgent.getRitual(provider, domains.TEST_DOMAIN, fakeRitualId);
+    const ritual = await DkgCoordinatorAgent.getRitual(
+      provider,
+      domains.TEST_DOMAIN,
+      fakeRitualId,
+    );
     expect(ritual).toBeDefined();
     expect(getRitualSpy).toHaveBeenCalled();
   });

--- a/packages/taco/test/dkg-client.test.ts
+++ b/packages/taco/test/dkg-client.test.ts
@@ -2,7 +2,7 @@ import { DkgCoordinatorAgent } from '@nucypher/shared';
 import { fakeProvider } from '@nucypher/test-utils';
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import { initialize } from '../src';
+import { domains, initialize } from '../src';
 
 import {
   fakeRitualId,
@@ -19,7 +19,7 @@ describe('DkgCoordinatorAgent', () => {
   it('fetches transcripts from the coordinator', async () => {
     const provider = fakeProvider();
     const getRitualSpy = mockGetRitual();
-    const ritual = await DkgCoordinatorAgent.getRitual(provider, fakeRitualId);
+    const ritual = await DkgCoordinatorAgent.getRitual(provider, domains.TEST_DOMAIN, fakeRitualId);
     expect(ritual).toBeDefined();
     expect(getRitualSpy).toHaveBeenCalled();
   });
@@ -31,6 +31,7 @@ describe('DkgCoordinatorAgent', () => {
     );
     const participants = await DkgCoordinatorAgent.getParticipants(
       provider,
+      domains.TEST_DOMAIN,
       fakeRitualId,
     );
     expect(getParticipantsSpy).toHaveBeenCalled();

--- a/packages/taco/test/test-utils.ts
+++ b/packages/taco/test/test-utils.ts
@@ -102,8 +102,7 @@ export const fakeDkgTDecFlowE2E: (
   };
 };
 
-export const fakeCoordinatorRitual = async (
-): Promise<CoordinatorRitual> => {
+export const fakeCoordinatorRitual = async (): Promise<CoordinatorRitual> => {
   const ritual = await fakeDkgTDecFlowE2E();
   const dkgPkBytes = ritual.dkg.publicKey().toBytes();
   return {
@@ -117,14 +116,15 @@ export const fakeCoordinatorRitual = async (
     publicKey: {
       word0: toHexString(dkgPkBytes.slice(0, 32)),
       word1: toHexString(dkgPkBytes.slice(32, 48)),
-    } as [string, string] & { // Casting to satisfy the type checker
+    } as [string, string] & {
+      // Casting to satisfy the type checker
       word0: string;
       word1: string;
     },
     endTimestamp: 0,
-    authority: "0x0",
+    authority: '0x0',
     threshold: ritual.threshold,
-    accessController: "0x0",
+    accessController: '0x0',
   };
 };
 
@@ -176,13 +176,9 @@ export const fakeDkgRitual = (ritual: {
 };
 
 export const mockGetRitual = (): SpyInstance => {
-  return vi
-    .spyOn(DkgCoordinatorAgent, 'getRitual')
-    .mockImplementation(
-      () => {
-        return Promise.resolve(fakeCoordinatorRitual());
-      },
-    );
+  return vi.spyOn(DkgCoordinatorAgent, 'getRitual').mockImplementation(() => {
+    return Promise.resolve(fakeCoordinatorRitual());
+  });
 };
 
 export const mockGetFinalizedRitual = (dkgRitual: DkgRitual): SpyInstance => {
@@ -267,13 +263,18 @@ export const testFunctionAbi: FunctionAbiProps = {
   ],
 };
 
-export const fakeConditionExpr = () => {
-  const condition = new ERC721Balance({
+export const fakeCondition = () =>
+  new ERC721Balance({
     chain: TEST_CHAIN_ID,
     contractAddress: TEST_CONTRACT_ADDR,
+    returnValueTest: {
+      index: 0,
+      comparator: '>=',
+      value: 0,
+    },
   });
-  return new ConditionExpression(condition);
-};
+
+export const fakeConditionExpr = () => new ConditionExpression(fakeCondition());
 
 export const mockGetParticipants = (
   participants: DkgParticipant[],

--- a/packages/taco/tsconfig.cjs.json
+++ b/packages/taco/tsconfig.cjs.json
@@ -2,6 +2,6 @@
   "extends": "./tsconfig.es.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "module": "CommonJS",
+    "module": "CommonJS"
   }
 }

--- a/packages/taco/tsconfig.json
+++ b/packages/taco/tsconfig.json
@@ -3,7 +3,7 @@
   "include": ["src", "test", "examples"],
   "compilerOptions": {
     "esModuleInterop": true,
-    "skipLibCheck": true,
+    "skipLibCheck": true
   },
   "references": [
     {

--- a/packages/taco/tsconfig.json
+++ b/packages/taco/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src", "test"],
+  "include": ["src", "test", "examples"],
   "compilerOptions": {
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:**
- 2


**What this does:**
- Adds support for `not` operator
- Refines error messages for `CompoundCondition`

**Issues fixed/closed:**
- Fixes #369

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
- Based on https://github.com/nucypher/nucypher-ts/pull/367. Please review it first.